### PR TITLE
Fix FastAPI main module syntax error

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -3,16 +3,20 @@ from __future__ import annotations
 import logging
 import sys
 
-STARTUP_LOGGER = logging.getLogger("ai_invoice.api.startup")
+from fastapi import Depends, FastAPI, HTTPException
+
 from ai_invoice.schemas import PredictiveResult
 
+
 STARTUP_LOGGER = logging.getLogger("ai_invoice.api.startup")
+
 
 try:
     from ai_invoice.config import settings
 except ValueError as exc:
     STARTUP_LOGGER.fatal("Invalid configuration detected during startup: %s", exc)
     raise SystemExit(1) from exc
+
 
 if not settings.api_key and not getattr(settings, "allow_anonymous", False):
     STARTUP_LOGGER.fatal(
@@ -21,15 +25,12 @@ if not settings.api_key and not getattr(settings, "allow_anonymous", False):
     raise SystemExit(1)
 
 
-from fastapi import Depends, FastAPI, HTTPException  # noqa: E402
-
-from ai_invoice.schemas import PredictiveResult
 from .license_validator import LicenseClaims, ensure_feature, require_feature_flag
 from .middleware import configure_middleware
 from .routers import health, invoices, models, predictive
 from .routers.invoices import PredictRequest, predict_from_features
 
-# Basic stdout logging
+
 handler = logging.StreamHandler(sys.stdout)
 formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s - %(message)s")
 handler.setFormatter(formatter)
@@ -37,14 +38,10 @@ root_logger = logging.getLogger()
 root_logger.handlers = [handler]
 root_logger.setLevel(logging.INFO)
 
+
 app = FastAPI(title="AI Invoice System")
 configure_middleware(app)
 
-# Routers:
-# - /health/      -> health.router
-# - /invoices/*   -> invoices.router (extract, classify, predict)
-# - /models/*     -> models.router (classifier status/train/classify)
-# - /models/predictive/* -> predictive.router (predictive status/train/predict)
 app.include_router(health.router)
 app.include_router(invoices.router)
 app.include_router(models.router)
@@ -56,7 +53,6 @@ def root() -> dict[str, str]:
     return {"message": "AI Invoice System API"}
 
 
-# Lightweight alias for /invoices/predict using the same schema/response
 @app.post("/predict", response_model=PredictiveResult, tags=["invoices"])
 def predict_endpoint(
     body: PredictRequest,
@@ -65,13 +61,6 @@ def predict_endpoint(
     ensure_feature(claims, "predict")
     try:
         return predict_from_features(body.features)
-try:
-    return predict_from_features(body.features)
-except HTTPException:
-    raise
-except ValueError as exc:
-    raise HTTPException(status_code=400, detail=str(exc)) from exc
-
     except ValueError as exc:
-        # Mirror behavior in the invoices router for invalid feature payloads
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+


### PR DESCRIPTION
## Summary
- simplify api.main imports and logging setup to avoid duplicate definitions
- validate configuration during startup before wiring middleware and routers
- clean the /predict endpoint logic to prevent the SyntaxError raised at import time

## Testing
- pytest (fails: IndentationError in src/ai_invoice/config.py unrelated to changes)


------
https://chatgpt.com/codex/tasks/task_e_68d35830cc9c8329aa9933e13765bde3