### PR TITLE
Add persistent settings store and admin portal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ PREDICTIVE_PATH=models/predictive.joblib
 
 # Authentication (used by FastAPI middleware and the .NET client)
 AI_API_KEY=change-me-super-secret
+ADMIN_API_KEY=change-me-admin-secret
+# Uncomment to explicitly allow unauthenticated requests (not recommended for production)
+# ALLOW_ANONYMOUS=false
 
 # Optional request validation knobs (not required; keep or tune as needed)
 MAX_UPLOAD_BYTES=5242880
@@ -10,3 +13,10 @@ MAX_TEXT_LENGTH=20000
 MAX_FEATURE_FIELDS=50
 # MAX_JSON_BODY_BYTES=
 # RATE_LIMIT_PER_MINUTE=
+# RATE_LIMIT_BURST=
+
+# CORS configuration (comma-separated origins; append |true to require credentials)
+# CORS_TRUSTED_ORIGINS=*
+
+# Override the default JSON settings location
+# AI_INVOICE_SETTINGS_PATH=data/settings.json

--- a/README.md
+++ b/README.md
@@ -96,18 +96,27 @@ This repository contains a cross-platform AI service (Python/FastAPI) and Window
 
 ### Configuration
 
-The API reads configuration from environment variables (or a `.env` file). Key knobs include:
+Configuration is now persisted to a JSON document (`data/settings.json` by default). Environment
+variables act as overrides and the web UI at `/admin` provides an authenticated way to review and
+modify settings. See [`docs/settings_management.md`](docs/settings_management.md) for a detailed
+walkthrough.
 
-| Variable                | Default   | Description                                                                 |
-| ----------------------- | --------- | --------------------------------------------------------------------------- |
-| `AI_API_KEY`            | *unset*   | Shared secret required in the `X-API-Key` header for all non-health routes. |
-| `MAX_UPLOAD_BYTES`      | `5242880` | Maximum allowed size for uploaded files (default: 5 MiB).                   |
-| `MAX_TEXT_LENGTH`       | `20000`   | Maximum characters accepted for classification endpoints.                   |
-| `MAX_FEATURE_FIELDS`    | `50`      | Maximum number of keys accepted in predictive feature payloads.             |
-| `MAX_JSON_BODY_BYTES`   | *unset*   | Optional upper bound (bytes) for JSON feature payloads.                     |
-| `RATE_LIMIT_PER_MINUTE` | *unset*   | Reserved for future throttling/telemetry integrations.                      |
+Common overrides:
 
-Set these before starting the server (via `.env` or environment variables) to tune request validation and security.
+| Variable | Default | Description |
+| --- | --- | --- |
+| `AI_API_KEY` / `API_KEY` | *unset* | Shared secret required in the `X-API-Key` header for all non-health routes. |
+| `ADMIN_API_KEY` | *unset* | Token required for the administrative API and UI. Falls back to `AI_API_KEY` if absent. |
+| `ALLOW_ANONYMOUS` | `false` | Allow requests without an API key (not recommended for production). |
+| `MAX_UPLOAD_BYTES` | `5242880` | Maximum allowed size for uploaded invoice files (default: 5 MiB). |
+| `MAX_TEXT_LENGTH` | `20000` | Maximum characters accepted for classification endpoints. |
+| `MAX_FEATURE_FIELDS` | `50` | Maximum number of keys accepted in predictive feature payloads. |
+| `MAX_JSON_BODY_BYTES` | *unset* | Optional upper bound (bytes) for JSON feature payloads. |
+| `RATE_LIMIT_PER_MINUTE` / `RATE_LIMIT_BURST` | *unset* | Enable request throttling when desired. |
+| `CORS_TRUSTED_ORIGINS` | `*` | Comma-separated origins (`https://app.example.com|true`). |
+
+The admin UI highlights fields that are currently controlled by environment overrides so you can
+decide which values should remain pinned to deployment-time configuration.
 
 ### Windows packaging
 

--- a/docs/settings_management.md
+++ b/docs/settings_management.md
@@ -1,0 +1,60 @@
+# Settings management
+
+The FastAPI service now persists configuration to a JSON document instead of relying solely on process
+environment variables. This makes it possible to manage authentication keys, request limits, and
+CORS configuration without redeploying the service.
+
+## Persistent configuration store
+
+* **Default location:** `data/settings.json`
+* **Override path:** set `AI_INVOICE_SETTINGS_PATH=/path/to/settings.json`
+
+The file stores all fields defined in `ai_invoice.config.Settings`. It is safe to edit manually when the
+service is offline, but the recommended approach is to use the administrative web UI (described below)
+so validation is applied consistently.
+
+The JSON store is loaded during application start. When the file is missing, defaults are applied and the
+file is created on first save through the API/UI.
+
+## Environment overrides
+
+Environment variables still work, but they now act as runtime overrides that take precedence over the
+JSON store. If an override exists, the admin UI highlights the corresponding field with an
+“Environment override” badge. The persisted value is still stored so that removing the environment
+variable later will fall back to the saved configuration.
+
+The most common overrides are:
+
+| Variable | Description |
+| --- | --- |
+| `AI_API_KEY` / `API_KEY` | Primary API token for request authentication. |
+| `ADMIN_API_KEY` | Token required by the administrative API/UI. Falls back to `AI_API_KEY` when unset. |
+| `ALLOW_ANONYMOUS` | Enable anonymous access to non-health endpoints. |
+| `CORS_TRUSTED_ORIGINS` | Comma separated list of origins. Append `|true` to require credentials. |
+| `MAX_UPLOAD_BYTES`, `MAX_TEXT_LENGTH`, `MAX_FEATURE_FIELDS` | Request validation knobs. |
+| `RATE_LIMIT_PER_MINUTE`, `RATE_LIMIT_BURST` | Token bucket limiter settings. |
+
+> The service will refuse to start when neither an API key nor `ALLOW_ANONYMOUS=true` is configured.
+
+## Administrative web UI
+
+1. Start the FastAPI application (e.g. `uv run uvicorn api.main:app --reload --port 8088`).
+2. Visit `http://localhost:8088/admin` in a browser.
+3. Provide the `ADMIN_API_KEY` (or `AI_API_KEY` if the admin key is unset) in the **Admin token** field.
+4. Update settings and click **Save changes**.
+
+The UI performs client-side validation and reports when values are currently driven by environment
+variables. All changes are persisted to the JSON store and immediately applied to the running
+application.
+
+## Migrating from `.env`
+
+1. Ensure your existing `.env` file is loaded (e.g. via `uv run --env-file .env ...`).
+2. Start the server and open the admin UI.
+3. Authenticate with the current admin token (`ADMIN_API_KEY` if present, otherwise `AI_API_KEY`).
+4. Review each section and click **Save changes** to persist the in-memory configuration to
+   `data/settings.json`.
+5. Remove secrets you no longer want in `.env`. Only keep overrides you intentionally want to lock.
+
+Going forward, routine changes can be performed in the UI. For automated deployments you can still
+manage settings by editing the JSON file or by providing environment variable overrides.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
   "fastapi>=0.112",
+  "jinja2>=3.1",
+  "httpx>=0.27",
   "uvicorn[standard]>=0.30",
   "pydantic>=2.7",
   "python-multipart>=0.0.9",

--- a/src/ai_invoice/config.py
+++ b/src/ai_invoice/config.py
@@ -1,19 +1,26 @@
+"""Application configuration and persistence helpers."""
+
 from __future__ import annotations
 
+import copy
 import os
-from dataclasses import dataclass, field
-from typing import Optional
+from dataclasses import MISSING, dataclass, field, fields
+from typing import Any, Optional
+
+from .settings_store import SettingsStore
 
 
 @dataclass(frozen=True, slots=True)
 class TrustedCORSOrigin:
     """Trusted origin entry describing credential requirements."""
+
     origin: str
     allow_credentials: bool = False
 
 
 def _parse_bool_env(value: str) -> bool:
     """Parse common boolean environment values."""
+
     normalized = value.strip().lower()
     truthy = {"1", "true", "t", "yes", "y", "on", "credentials"}
     falsy = {"0", "false", "f", "no", "n", "off"}
@@ -27,21 +34,16 @@ def _parse_bool_env(value: str) -> bool:
     )
 
 
+def _default_cors_origins() -> list[TrustedCORSOrigin]:
+    return [TrustedCORSOrigin(origin="*", allow_credentials=False)]
+
+
 def _get_cors_trusted_origins() -> list[TrustedCORSOrigin]:
-    """Read trusted CORS origins from the environment.
+    """Read trusted CORS origins from the environment."""
 
-    Format (comma-separated):
-      - "*"
-      - "https://example.com"
-      - "https://app.example.com|true"  # allow credentials for this origin
-
-    Rules:
-      - Wildcard '*' cannot be combined with other origins.
-      - Credentials cannot be required for wildcard origins.
-    """
     raw = os.getenv("CORS_TRUSTED_ORIGINS")
     if raw is None or raw.strip() == "":
-        return [TrustedCORSOrigin(origin="*", allow_credentials=False)]
+        return _default_cors_origins()
 
     entries: list[TrustedCORSOrigin] = []
     for chunk in raw.split(","):
@@ -78,11 +80,12 @@ def _get_cors_trusted_origins() -> list[TrustedCORSOrigin]:
 
         entries.append(TrustedCORSOrigin(origin=origin, allow_credentials=allow_credentials))
 
-    return entries or [TrustedCORSOrigin(origin="*", allow_credentials=False)]
+    return entries or _default_cors_origins()
 
 
 def _get_int_env(name: str, default: Optional[int] = None) -> Optional[int]:
     """Read an integer environment variable with optional default."""
+
     raw = os.getenv(name)
     if raw is None or raw.strip() == "":
         return default
@@ -97,6 +100,7 @@ def _get_int_env(name: str, default: Optional[int] = None) -> Optional[int]:
 
 def _get_csv_env(name: str) -> frozenset[str]:
     """Parse a comma-delimited environment variable into a frozen set."""
+
     raw = os.getenv(name)
     if raw is None or raw.strip() == "":
         return frozenset()
@@ -106,6 +110,7 @@ def _get_csv_env(name: str) -> frozenset[str]:
 
 def _get_bool_env(name: str, default: bool = False) -> bool:
     """Read a boolean environment variable."""
+
     raw = os.getenv(name)
     if raw is None or raw.strip() == "":
         return default
@@ -124,6 +129,7 @@ def _get_bool_env(name: str, default: bool = False) -> bool:
 
 def _get_api_key() -> Optional[str]:
     """Support both AI_API_KEY (preferred) and API_KEY for backward compatibility."""
+
     key = os.getenv("AI_API_KEY") or os.getenv("API_KEY")
     if key is None:
         return None
@@ -131,97 +137,413 @@ def _get_api_key() -> Optional[str]:
     return key or None
 
 
+def _normalize_optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value).strip() or None
+
+
+def _coerce_required_int(value: Any, field_name: str) -> int:
+    coerced = _coerce_optional_int(value, field_name)
+    if coerced is None:
+        raise ValueError(f"{field_name} must be configured with a non-negative integer.")
+    return coerced
+
+
+def _coerce_optional_int(value: Any, field_name: str) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be an integer, not a boolean.")
+    if isinstance(value, int):
+        if value < 0:
+            raise ValueError(f"{field_name} must be non-negative.")
+        return value
+    text = str(value).strip()
+    if text == "":
+        return None
+    try:
+        parsed = int(text)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be an integer value.") from exc
+    if parsed < 0:
+        raise ValueError(f"{field_name} must be non-negative.")
+    return parsed
+
+
+def _normalize_str_collection(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (set, frozenset, list, tuple)):
+        items = value
+    else:
+        items = [value]
+    normalized: list[str] = []
+    for item in items:
+        text = str(item).strip()
+        if text:
+            normalized.append(text)
+    return normalized
+
+
 @dataclass(slots=True)
 class Settings:
-    """Application configuration sourced from environment variables."""
+    """Application configuration sourced from persisted storage and environment."""
 
     # Model paths
-    classifier_path: str = field(
-        default_factory=lambda: os.getenv("CLASSIFIER_PATH", "models/classifier.joblib")
-    )
-    predictive_path: str = field(
-        default_factory=lambda: os.getenv("PREDICTIVE_PATH", "models/predictive.joblib")
-    )
+    classifier_path: str = "models/classifier.joblib"
+    predictive_path: str = "models/predictive.joblib"
 
     # Auth
-    api_key: Optional[str] = field(default_factory=_get_api_key)
-    # Explicit opt-out switch so devs must choose to run without an API key.
-    allow_anonymous: bool = field(
-        default_factory=lambda: _get_bool_env("ALLOW_ANONYMOUS", False)
-    )
+    api_key: Optional[str] = None
+    admin_api_key: Optional[str] = None
+    allow_anonymous: bool = False
 
     # License configuration
-    license_public_key_path: Optional[str] = field(
-        default_factory=lambda: os.getenv("LICENSE_PUBLIC_KEY_PATH")
-    )
-    license_public_key: Optional[str] = field(
-        default_factory=lambda: os.getenv("LICENSE_PUBLIC_KEY")
-    )
-    license_algorithm: str = field(
-        default_factory=lambda: os.getenv("LICENSE_ALGORITHM", "RS256")
-    )
-    license_revoked_jtis: frozenset[str] = field(
-        default_factory=lambda: _get_csv_env("LICENSE_REVOKED_JTIS")
-    )
-    license_revoked_subjects: frozenset[str] = field(
-        default_factory=lambda: _get_csv_env("LICENSE_REVOKED_SUBJECTS")
-    )
+    license_public_key_path: Optional[str] = None
+    license_public_key: Optional[str] = None
+    license_algorithm: str = "RS256"
+    license_revoked_jtis: frozenset[str] = field(default_factory=frozenset)
+    license_revoked_subjects: frozenset[str] = field(default_factory=frozenset)
 
     # Request validation
-    max_upload_bytes: int = field(
-        default_factory=lambda: _get_int_env("MAX_UPLOAD_BYTES", 5 * 1024 * 1024)
-    )
-    max_text_length: int = field(
-        default_factory=lambda: _get_int_env("MAX_TEXT_LENGTH", 20_000)
-    )
-    max_feature_fields: int = field(
-        default_factory=lambda: _get_int_env("MAX_FEATURE_FIELDS", 50)
-    )
-    max_json_body_bytes: Optional[int] = field(
-        default_factory=lambda: _get_int_env("MAX_JSON_BODY_BYTES")
-    )
+    max_upload_bytes: int = 5 * 1024 * 1024
+    max_text_length: int = 20_000
+    max_feature_fields: int = 50
+    max_json_body_bytes: Optional[int] = None
 
     # Rate limiting knobs (not yet enforced in middleware)
-    rate_limit_per_minute: Optional[int] = field(
-        default_factory=lambda: _get_int_env("RATE_LIMIT_PER_MINUTE")
-    )
-    rate_limit_burst: Optional[int] = field(
-        default_factory=lambda: _get_int_env("RATE_LIMIT_BURST")
-    )
+    rate_limit_per_minute: Optional[int] = None
+    rate_limit_burst: Optional[int] = None
 
     # CORS
-    cors_trusted_origins: list[TrustedCORSOrigin] = field(
-        default_factory=_get_cors_trusted_origins
-    )
+    cors_trusted_origins: list[TrustedCORSOrigin] = field(default_factory=_default_cors_origins)
 
     def __post_init__(self) -> None:
-        # Enforce explicit choice: either set an API key or opt into anonymous mode.
+        self.classifier_path = self.classifier_path.strip()
+        self.predictive_path = self.predictive_path.strip()
+
+        self.api_key = _normalize_optional_str(self.api_key)
+        self.admin_api_key = _normalize_optional_str(self.admin_api_key)
+        self.allow_anonymous = bool(self.allow_anonymous)
+
+        self.license_public_key_path = _normalize_optional_str(self.license_public_key_path)
+        self.license_public_key = _normalize_optional_str(self.license_public_key)
+
+        self.license_revoked_jtis = frozenset(_normalize_str_collection(self.license_revoked_jtis))
+        self.license_revoked_subjects = frozenset(
+            _normalize_str_collection(self.license_revoked_subjects)
+        )
+
+        self.max_upload_bytes = _coerce_required_int(self.max_upload_bytes, "max_upload_bytes")
+        self.max_text_length = _coerce_required_int(self.max_text_length, "max_text_length")
+        self.max_feature_fields = _coerce_required_int(
+            self.max_feature_fields, "max_feature_fields"
+        )
+        self.max_json_body_bytes = _coerce_optional_int(
+            self.max_json_body_bytes, "max_json_body_bytes"
+        )
+        self.rate_limit_per_minute = _coerce_optional_int(
+            self.rate_limit_per_minute, "rate_limit_per_minute"
+        )
+        self.rate_limit_burst = _coerce_optional_int(self.rate_limit_burst, "rate_limit_burst")
+
         if not self.api_key and not self.allow_anonymous:
             raise ValueError(
                 "AI_API_KEY (or API_KEY) must be set unless ALLOW_ANONYMOUS=true is explicitly configured."
             )
 
-        # Normalize/resolve license config
-        if not self.license_public_key and self.license_public_key_path:
+        if not self.admin_api_key and self.api_key:
+            self.admin_api_key = self.api_key
+
+        if self.license_public_key_path and not self.license_public_key:
             try:
                 with open(self.license_public_key_path, "r", encoding="utf-8") as handle:
-                    object.__setattr__(self, "license_public_key", handle.read())
+                    self.license_public_key = handle.read().strip() or None
             except OSError as exc:  # pragma: no cover - defensive
                 raise RuntimeError(
                     f"Unable to read license public key from {self.license_public_key_path!r}."
                 ) from exc
 
         if self.license_public_key:
-            object.__setattr__(self, "license_public_key", self.license_public_key.strip())
+            self.license_public_key = self.license_public_key.strip()
 
         alg = (self.license_algorithm or "RS256").strip().upper()
-        object.__setattr__(self, "license_algorithm", alg or "RS256")
+        self.license_algorithm = alg or "RS256"
 
-        # Ensure revoked sets are normalized (trim whitespace)
-        cleaned_jtis = frozenset(entry.strip() for entry in self.license_revoked_jtis if entry.strip())
-        cleaned_subjects = frozenset(entry.strip() for entry in self.license_revoked_subjects if entry.strip())
-        object.__setattr__(self, "license_revoked_jtis", cleaned_jtis)
-        object.__setattr__(self, "license_revoked_subjects", cleaned_subjects)
+        self.cors_trusted_origins = self._normalize_cors_entries(self.cors_trusted_origins)
+
+    @staticmethod
+    def _normalize_cors_entries(
+        raw_entries: list[TrustedCORSOrigin] | list[dict[str, Any]] | list[Any]
+    ) -> list[TrustedCORSOrigin]:
+        entries: list[TrustedCORSOrigin] = []
+        for entry in raw_entries or []:
+            if isinstance(entry, TrustedCORSOrigin):
+                entries.append(entry)
+                continue
+            if isinstance(entry, dict):
+                origin = _normalize_optional_str(entry.get("origin"))
+                if not origin:
+                    raise ValueError("CORS origins must include a non-empty origin value.")
+                allow_credentials = bool(entry.get("allow_credentials", False))
+                entries.append(TrustedCORSOrigin(origin=origin, allow_credentials=allow_credentials))
+                continue
+            if isinstance(entry, str):
+                origin = entry.strip()
+                if origin:
+                    entries.append(TrustedCORSOrigin(origin=origin, allow_credentials=False))
+                continue
+            raise TypeError(
+                "cors_trusted_origins entries must be dicts, strings, or TrustedCORSOrigin instances."
+            )
+
+        if not entries:
+            entries = _default_cors_origins()
+
+        wildcard = [item for item in entries if item.origin == "*"]
+        if wildcard:
+            if len(entries) > len(wildcard):
+                raise ValueError("CORS wildcard origin cannot be combined with other origins.")
+            if any(item.allow_credentials for item in wildcard):
+                raise ValueError("CORS wildcard origin may not require credentials.")
+
+        return entries
 
 
-settings = Settings()
+_settings_store = SettingsStore()
+_SETTINGS_FIELD_NAMES = {field.name for field in fields(Settings)}
+_ENV_OVERRIDE_FIELDS: set[str] = set()
+
+
+def _settings_defaults() -> dict[str, Any]:
+    defaults: dict[str, Any] = {}
+    for item in fields(Settings):
+        if item.default is not MISSING:
+            defaults[item.name] = copy.deepcopy(item.default)
+        elif item.default_factory is not MISSING:  # type: ignore[attr-defined]
+            defaults[item.name] = item.default_factory()
+    return defaults
+
+
+def _sanitize_store_data(raw: dict[str, Any]) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {}
+    for key, value in raw.items():
+        if key in _SETTINGS_FIELD_NAMES:
+            sanitized[key] = copy.deepcopy(value)
+    return sanitized
+
+
+def _collect_env_overrides(base: dict[str, Any]) -> tuple[dict[str, Any], set[str]]:
+    overrides: dict[str, Any] = {}
+    override_fields: set[str] = set()
+
+    if "CLASSIFIER_PATH" in os.environ:
+        overrides["classifier_path"] = os.getenv("CLASSIFIER_PATH") or base.get("classifier_path")
+        override_fields.add("classifier_path")
+
+    if "PREDICTIVE_PATH" in os.environ:
+        overrides["predictive_path"] = os.getenv("PREDICTIVE_PATH") or base.get("predictive_path")
+        override_fields.add("predictive_path")
+
+    if any(env in os.environ for env in ("AI_API_KEY", "API_KEY")):
+        overrides["api_key"] = _get_api_key()
+        override_fields.add("api_key")
+
+    if "ADMIN_API_KEY" in os.environ:
+        overrides["admin_api_key"] = _normalize_optional_str(os.getenv("ADMIN_API_KEY"))
+        override_fields.add("admin_api_key")
+
+    if "ALLOW_ANONYMOUS" in os.environ:
+        overrides["allow_anonymous"] = _get_bool_env(
+            "ALLOW_ANONYMOUS", bool(base.get("allow_anonymous", False))
+        )
+        override_fields.add("allow_anonymous")
+
+    if "LICENSE_PUBLIC_KEY_PATH" in os.environ:
+        overrides["license_public_key_path"] = _normalize_optional_str(
+            os.getenv("LICENSE_PUBLIC_KEY_PATH")
+        )
+        override_fields.add("license_public_key_path")
+
+    if "LICENSE_PUBLIC_KEY" in os.environ:
+        overrides["license_public_key"] = _normalize_optional_str(
+            os.getenv("LICENSE_PUBLIC_KEY")
+        )
+        override_fields.add("license_public_key")
+
+    if "LICENSE_ALGORITHM" in os.environ:
+        overrides["license_algorithm"] = os.getenv("LICENSE_ALGORITHM")
+        override_fields.add("license_algorithm")
+
+    if "LICENSE_REVOKED_JTIS" in os.environ:
+        overrides["license_revoked_jtis"] = _get_csv_env("LICENSE_REVOKED_JTIS")
+        override_fields.add("license_revoked_jtis")
+
+    if "LICENSE_REVOKED_SUBJECTS" in os.environ:
+        overrides["license_revoked_subjects"] = _get_csv_env("LICENSE_REVOKED_SUBJECTS")
+        override_fields.add("license_revoked_subjects")
+
+    if "MAX_UPLOAD_BYTES" in os.environ:
+        overrides["max_upload_bytes"] = _get_int_env(
+            "MAX_UPLOAD_BYTES", base.get("max_upload_bytes")
+        )
+        override_fields.add("max_upload_bytes")
+
+    if "MAX_TEXT_LENGTH" in os.environ:
+        overrides["max_text_length"] = _get_int_env(
+            "MAX_TEXT_LENGTH", base.get("max_text_length")
+        )
+        override_fields.add("max_text_length")
+
+    if "MAX_FEATURE_FIELDS" in os.environ:
+        overrides["max_feature_fields"] = _get_int_env(
+            "MAX_FEATURE_FIELDS", base.get("max_feature_fields")
+        )
+        override_fields.add("max_feature_fields")
+
+    if "MAX_JSON_BODY_BYTES" in os.environ:
+        overrides["max_json_body_bytes"] = _get_int_env(
+            "MAX_JSON_BODY_BYTES", base.get("max_json_body_bytes")
+        )
+        override_fields.add("max_json_body_bytes")
+
+    if "RATE_LIMIT_PER_MINUTE" in os.environ:
+        overrides["rate_limit_per_minute"] = _get_int_env(
+            "RATE_LIMIT_PER_MINUTE", base.get("rate_limit_per_minute")
+        )
+        override_fields.add("rate_limit_per_minute")
+
+    if "RATE_LIMIT_BURST" in os.environ:
+        overrides["rate_limit_burst"] = _get_int_env(
+            "RATE_LIMIT_BURST", base.get("rate_limit_burst")
+        )
+        override_fields.add("rate_limit_burst")
+
+    if "CORS_TRUSTED_ORIGINS" in os.environ:
+        overrides["cors_trusted_origins"] = _get_cors_trusted_origins()
+        override_fields.add("cors_trusted_origins")
+
+    return overrides, override_fields
+
+
+def _settings_to_payload(data: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for name in _SETTINGS_FIELD_NAMES:
+        if name not in data:
+            continue
+        value = data[name]
+        if name in {"license_revoked_jtis", "license_revoked_subjects"}:
+            payload[name] = sorted(_normalize_str_collection(value))
+        elif name == "cors_trusted_origins":
+            origins_payload: list[dict[str, Any]] = []
+            for item in value or []:
+                if isinstance(item, TrustedCORSOrigin):
+                    origins_payload.append(
+                        {
+                            "origin": item.origin,
+                            "allow_credentials": bool(item.allow_credentials),
+                        }
+                    )
+                elif isinstance(item, dict):
+                    origin = _normalize_optional_str(item.get("origin"))
+                    if origin:
+                        origins_payload.append(
+                            {
+                                "origin": origin,
+                                "allow_credentials": bool(item.get("allow_credentials", False)),
+                            }
+                        )
+                elif isinstance(item, str):
+                    origin = item.strip()
+                    if origin:
+                        origins_payload.append({"origin": origin, "allow_credentials": False})
+            payload[name] = origins_payload
+        else:
+            payload[name] = value
+    return payload
+
+
+def _load_settings_and_overrides() -> tuple[Settings, set[str]]:
+    defaults = _settings_defaults()
+    stored_raw = _settings_store.load()
+    stored = _sanitize_store_data(stored_raw)
+    data: dict[str, Any] = {**defaults, **stored}
+    env_overrides, override_fields = _collect_env_overrides(data)
+    data.update(env_overrides)
+    settings_obj = Settings(**data)
+    return settings_obj, override_fields
+
+
+def _apply_settings(new_settings: Settings, overrides: set[str]) -> None:
+    global _ENV_OVERRIDE_FIELDS
+    for item in fields(Settings):
+        setattr(settings, item.name, getattr(new_settings, item.name))
+    _ENV_OVERRIDE_FIELDS = set(overrides)
+
+
+def reload_settings() -> Settings:
+    """Reload settings from disk and environment, mutating the shared instance."""
+
+    new_settings, overrides = _load_settings_and_overrides()
+    _apply_settings(new_settings, overrides)
+    return settings
+
+
+def update_persisted_settings(partial: dict[str, Any]) -> Settings:
+    """Persist updated settings and refresh the in-memory configuration."""
+
+    if not partial:
+        return reload_settings()
+
+    stored_raw = _settings_store.load()
+    stored = _sanitize_store_data(stored_raw)
+    for key, value in partial.items():
+        if key in _SETTINGS_FIELD_NAMES:
+            stored[key] = copy.deepcopy(value)
+
+    payload = _settings_to_payload(stored)
+    _settings_store.save(payload)
+    return reload_settings()
+
+
+def export_settings() -> dict[str, Any]:
+    """Return a JSON-serializable representation of the active settings."""
+
+    data: dict[str, Any] = {}
+    for item in fields(Settings):
+        value = getattr(settings, item.name)
+        if item.name in {"license_revoked_jtis", "license_revoked_subjects"}:
+            data[item.name] = sorted(value)
+        elif item.name == "cors_trusted_origins":
+            data[item.name] = [
+                {"origin": origin.origin, "allow_credentials": origin.allow_credentials}
+                for origin in value
+            ]
+        else:
+            data[item.name] = value
+    return data
+
+
+def get_environment_overrides() -> dict[str, bool]:
+    """Expose which fields are currently controlled by environment variables."""
+
+    return {name: (name in _ENV_OVERRIDE_FIELDS) for name in _SETTINGS_FIELD_NAMES}
+
+
+settings, _ENV_OVERRIDE_FIELDS = _load_settings_and_overrides()
+
+
+__all__ = [
+    "Settings",
+    "TrustedCORSOrigin",
+    "export_settings",
+    "get_environment_overrides",
+    "reload_settings",
+    "settings",
+    "update_persisted_settings",
+]
+

--- a/src/ai_invoice/settings_store.py
+++ b/src/ai_invoice/settings_store.py
@@ -1,0 +1,61 @@
+"""Persistence backend for configuration settings."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+
+class SettingsStore:
+    """Simple JSON-backed settings repository."""
+
+    def __init__(self, *, default_path: str | Path | None = None) -> None:
+        base_path = default_path or "data/settings.json"
+        self._default_path = Path(base_path)
+
+    @property
+    def path(self) -> Path:
+        """Resolve the active settings path, honoring environment overrides."""
+
+        override = os.getenv("AI_INVOICE_SETTINGS_PATH")
+        if override and override.strip():
+            return Path(override).expanduser()
+        return self._default_path
+
+    def load(self) -> dict[str, Any]:
+        """Load persisted settings, returning an empty mapping if missing."""
+
+        target = self.path
+        if not target.exists():
+            return {}
+        try:
+            with target.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise RuntimeError(
+                f"Settings file at {target} is not valid JSON: {exc.msg}"
+            ) from exc
+        if not isinstance(data, dict):  # pragma: no cover - defensive
+            raise RuntimeError("Settings file must contain a JSON object at the top level.")
+        return data
+
+    def save(self, payload: dict[str, Any]) -> None:
+        """Persist settings atomically to disk."""
+
+        target = self.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        serialized = json.dumps(payload, indent=2, sort_keys=True)
+        with NamedTemporaryFile(
+            "w", encoding="utf-8", dir=str(target.parent), delete=False
+        ) as handle:
+            handle.write(serialized)
+            handle.write("\n")
+            temp_name = handle.name
+        os.replace(temp_name, target)
+
+
+__all__ = ["SettingsStore"]
+

--- a/src/api/routers/admin.py
+++ b/src/api/routers/admin.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import hmac
+from typing import Any
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+
+from ai_invoice.config import (
+    export_settings,
+    get_environment_overrides,
+    settings,
+    update_persisted_settings,
+)
+
+from ..security import reset_license_verifier_cache
+
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+class CorsOriginModel(BaseModel):
+    origin: str = Field(..., min_length=1, description="CORS origin (e.g., https://app.example.com)")
+    allow_credentials: bool = Field(
+        False, description="Whether requests from this origin must include credentials"
+    )
+
+    @field_validator("origin")
+    @classmethod
+    def _normalize_origin(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("origin must not be empty")
+        return normalized
+
+
+class SettingsDocument(BaseModel):
+    classifier_path: str
+    predictive_path: str
+    api_key: str | None = Field(default=None, description="API key required for client access")
+    admin_api_key: str | None = Field(
+        default=None, description="Secret used to access the administrative API"
+    )
+    allow_anonymous: bool = Field(
+        False, description="Allow unauthenticated requests when no API key is present"
+    )
+    license_public_key_path: str | None = Field(default=None)
+    license_public_key: str | None = Field(default=None)
+    license_algorithm: str = Field("RS256", min_length=2)
+    license_revoked_jtis: list[str] = Field(default_factory=list)
+    license_revoked_subjects: list[str] = Field(default_factory=list)
+    max_upload_bytes: int = Field(..., ge=0)
+    max_text_length: int = Field(..., ge=0)
+    max_feature_fields: int = Field(..., ge=0)
+    max_json_body_bytes: int | None = Field(default=None, ge=0)
+    rate_limit_per_minute: int | None = Field(default=None, ge=0)
+    rate_limit_burst: int | None = Field(default=None, ge=0)
+    cors_trusted_origins: list[CorsOriginModel] = Field(default_factory=list)
+
+    @field_validator("license_algorithm")
+    @classmethod
+    def _normalize_algorithm(cls, value: str) -> str:
+        normalized = value.strip().upper()
+        return normalized or "RS256"
+
+    @field_validator("license_revoked_jtis", "license_revoked_subjects", mode="before")
+    @classmethod
+    def _clean_revoked(cls, value: Any) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, (set, frozenset, tuple)):
+            iterable = list(value)
+        elif isinstance(value, str):
+            stripped = value.strip()
+            return [stripped] if stripped else []
+        else:
+            iterable = value
+        return [str(item).strip() for item in iterable if str(item).strip()]
+
+
+class SettingsEnvelope(BaseModel):
+    values: SettingsDocument
+    overrides: dict[str, bool]
+
+
+def require_admin_token(x_admin_token: str | None = Header(default=None)) -> None:
+    secret = getattr(settings, "admin_api_key", None)
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Administrative API is not configured.",
+        )
+    if not x_admin_token or not hmac.compare_digest(secret, x_admin_token):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid admin token.")
+
+
+@router.get("/settings", response_model=SettingsEnvelope)
+def read_settings(_: None = Depends(require_admin_token)) -> SettingsEnvelope:
+    payload = export_settings()
+    document = SettingsDocument(**payload)
+    overrides = get_environment_overrides()
+    return SettingsEnvelope(values=document, overrides=overrides)
+
+
+@router.put("/settings", response_model=SettingsEnvelope)
+def update_settings(document: SettingsDocument, _: None = Depends(require_admin_token)) -> SettingsEnvelope:
+    payload = document.model_dump()
+    payload["cors_trusted_origins"] = [
+        {
+            "origin": item.origin,
+            "allow_credentials": item.allow_credentials,
+        }
+        for item in document.cors_trusted_origins
+    ]
+    update_persisted_settings(payload)
+    reset_license_verifier_cache()
+    refreshed = export_settings()
+    overrides = get_environment_overrides()
+    return SettingsEnvelope(values=SettingsDocument(**refreshed), overrides=overrides)
+
+
+__all__ = ["router"]
+

--- a/src/api/static/css/admin.css
+++ b/src/api/static/css/admin.css
@@ -1,0 +1,276 @@
+:root {
+  color-scheme: light;
+  --bg: #f4f6f8;
+  --card-bg: #ffffff;
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  --text: #1f2933;
+  --muted: #617085;
+  --border: #d0d7e2;
+  --danger: #b91c1c;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.app-shell {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 40px 24px 60px;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.app-header h1 {
+  font-size: 2rem;
+  margin: 0;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 16px;
+  padding: 28px;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(226, 232, 240, 0.6);
+  margin-bottom: 28px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.card h2 {
+  margin: 0 0 12px;
+  font-size: 1.5rem;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.925rem;
+  margin: 6px 0 0;
+}
+
+.auth-grid {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+  margin-top: 16px;
+}
+
+.auth-grid .text-input {
+  grid-column: span 2;
+}
+
+.auth-grid .remember-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.field-label {
+  font-weight: 600;
+}
+
+.form-section {
+  margin-bottom: 28px;
+}
+
+.form-section h3 {
+  margin: 0 0 16px;
+  font-size: 1.2rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #fafbff;
+}
+
+.form-row.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+}
+
+.form-row.checkbox label {
+  flex: 1;
+  margin: 0;
+}
+
+.form-row label {
+  font-weight: 600;
+}
+
+.text-input,
+.text-area {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  font: inherit;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  background: #ffffff;
+}
+
+.text-input:focus,
+.text-area:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  outline: none;
+}
+
+.text-area {
+  resize: vertical;
+}
+
+.primary,
+.secondary {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 20px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.primary {
+  background: var(--primary);
+  color: #ffffff;
+}
+
+.primary:hover {
+  background: var(--primary-hover);
+  transform: translateY(-1px);
+}
+
+.secondary {
+  background: transparent;
+  color: var(--primary);
+  border: 1px solid rgba(37, 99, 235, 0.4);
+}
+
+.secondary:hover {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 24px;
+}
+
+.status-message {
+  margin-top: 16px;
+  font-weight: 500;
+}
+
+.status-message.info {
+  color: var(--muted);
+}
+
+.status-message.success {
+  color: #047857;
+}
+
+.status-message.error {
+  color: var(--danger);
+}
+
+.error {
+  color: var(--danger);
+}
+
+.hidden {
+  display: none !important;
+}
+
+.override-note {
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  align-self: flex-start;
+  color: var(--primary);
+}
+
+.form-row.overridden {
+  border-color: rgba(37, 99, 235, 0.5);
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.form-row.invalid {
+  border-color: rgba(185, 28, 28, 0.55);
+  background: rgba(185, 28, 28, 0.07);
+}
+
+.card-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    padding: 24px 16px 40px;
+  }
+
+  .auth-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-grid .text-input,
+  .auth-grid button {
+    grid-column: span 1;
+  }
+
+  .card {
+    padding: 24px;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .form-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/src/api/static/js/admin.js
+++ b/src/api/static/js/admin.js
@@ -1,0 +1,414 @@
+const STORAGE_KEY = "ai_invoice_admin_token";
+const BOOLEAN_TRUE = new Set(["true", "1", "yes", "y", "on"]);
+const BOOLEAN_FALSE = new Set(["false", "0", "no", "n", "off"]);
+
+const tokenInput = document.getElementById("admin-token");
+const rememberToggle = document.getElementById("remember-token");
+const loadButton = document.getElementById("load-settings");
+const refreshButton = document.getElementById("refresh-settings");
+const resetButton = document.getElementById("reset-form");
+const settingsCard = document.getElementById("settings-card");
+const authError = document.getElementById("auth-error");
+const statusMessage = document.getElementById("status-message");
+const form = document.getElementById("settings-form");
+
+let adminToken = "";
+let lastPayload = null;
+let lastOverrides = {};
+
+function setStatus(message, type) {
+  statusMessage.textContent = message || "";
+  statusMessage.className = "status-message";
+  if (type) {
+    statusMessage.classList.add(type);
+  }
+}
+
+function clearStatus() {
+  setStatus("", "");
+}
+
+function setAuthError(message) {
+  authError.textContent = message;
+  authError.classList.remove("hidden");
+}
+
+function clearAuthError() {
+  authError.textContent = "";
+  authError.classList.add("hidden");
+}
+
+function updateRememberStorage() {
+  if (rememberToggle.checked && adminToken) {
+    window.localStorage.setItem(STORAGE_KEY, adminToken);
+  } else {
+    window.localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+function initializeToken() {
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    rememberToggle.checked = true;
+    tokenInput.value = stored;
+    adminToken = stored;
+  }
+}
+
+function clearValidationIndicators() {
+  document.querySelectorAll(".form-row").forEach((row) => {
+    row.classList.remove("invalid");
+  });
+}
+
+function applyOverrides(overrides) {
+  lastOverrides = overrides || {};
+  document.querySelectorAll(".form-row").forEach((row) => {
+    row.classList.remove("overridden");
+  });
+  document.querySelectorAll(".override-note").forEach((note) => {
+    note.classList.add("hidden");
+  });
+  Object.entries(lastOverrides).forEach(([field, isOverride]) => {
+    if (!isOverride) {
+      return;
+    }
+    const row = document.querySelector(`.form-row[data-field="${field}"]`);
+    const note = document.querySelector(`.override-note[data-override="${field}"]`);
+    if (row) {
+      row.classList.add("overridden");
+    }
+    if (note) {
+      note.classList.remove("hidden");
+    }
+  });
+}
+
+function markFieldError(fieldName, message) {
+  setStatus(message, "error");
+  const row = document.querySelector(`.form-row[data-field="${fieldName}"]`);
+  if (row) {
+    row.classList.add("invalid");
+  }
+}
+
+function readIntField(id, { required }) {
+  const input = document.getElementById(id);
+  const text = input.value.trim();
+  if (!text) {
+    if (required) {
+      markFieldError(id, "This value is required.");
+      return { ok: false };
+    }
+    return { ok: true, value: null };
+  }
+  const value = Number(text);
+  if (!Number.isInteger(value) || value < 0) {
+    markFieldError(id, "Enter a non-negative integer.");
+    return { ok: false };
+  }
+  return { ok: true, value };
+}
+
+function parseList(id) {
+  const value = document.getElementById(id).value;
+  if (!value.trim()) {
+    return [];
+  }
+  const separators = /[,\n]/;
+  return value
+    .split(separators)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function parseCorsOrigins(rawValue) {
+  if (!rawValue.trim()) {
+    return { ok: true, value: [] };
+  }
+  const entries = [];
+  for (const line of rawValue.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const [originPart, flagPart] = trimmed.split("|", 2);
+    const origin = originPart.trim();
+    if (!origin) {
+      return { ok: false, message: "Each origin must include a value." };
+    }
+    let allowCredentials = false;
+    if (flagPart !== undefined) {
+      const normalizedFlag = flagPart.trim().toLowerCase();
+      if (BOOLEAN_TRUE.has(normalizedFlag)) {
+        allowCredentials = true;
+      } else if (BOOLEAN_FALSE.has(normalizedFlag) || normalizedFlag === "") {
+        allowCredentials = false;
+      } else {
+        return {
+          ok: false,
+          message: `Unable to parse credentials flag for ${origin}. Use true/false.`,
+        };
+      }
+    }
+    entries.push({ origin, allow_credentials: allowCredentials });
+  }
+
+  const wildcardEntries = entries.filter((entry) => entry.origin === "*");
+  if (wildcardEntries.length > 0) {
+    if (entries.length > wildcardEntries.length) {
+      return {
+        ok: false,
+        message: "Wildcard origin cannot be combined with other origins.",
+      };
+    }
+    if (wildcardEntries.some((entry) => entry.allow_credentials)) {
+      return {
+        ok: false,
+        message: "Wildcard origin cannot require credentials.",
+      };
+    }
+  }
+
+  return { ok: true, value: entries };
+}
+
+function populateForm(values) {
+  lastPayload = JSON.parse(JSON.stringify(values));
+  document.getElementById("classifier_path").value = values.classifier_path || "";
+  document.getElementById("predictive_path").value = values.predictive_path || "";
+  document.getElementById("api_key").value = values.api_key || "";
+  document.getElementById("admin_api_key").value = values.admin_api_key || "";
+  document.getElementById("allow_anonymous").checked = Boolean(values.allow_anonymous);
+  document.getElementById("license_public_key_path").value = values.license_public_key_path || "";
+  document.getElementById("license_public_key").value = values.license_public_key || "";
+  document.getElementById("license_algorithm").value = values.license_algorithm || "";
+  document.getElementById("license_revoked_jtis").value = (values.license_revoked_jtis || []).join("\n");
+  document.getElementById("license_revoked_subjects").value = (values.license_revoked_subjects || []).join("\n");
+  document.getElementById("max_upload_bytes").value = values.max_upload_bytes ?? "";
+  document.getElementById("max_text_length").value = values.max_text_length ?? "";
+  document.getElementById("max_feature_fields").value = values.max_feature_fields ?? "";
+  document.getElementById("max_json_body_bytes").value = values.max_json_body_bytes ?? "";
+  document.getElementById("rate_limit_per_minute").value = values.rate_limit_per_minute ?? "";
+  document.getElementById("rate_limit_burst").value = values.rate_limit_burst ?? "";
+
+  const corsLines = (values.cors_trusted_origins || []).map((entry) =>
+    entry.allow_credentials ? `${entry.origin}|true` : entry.origin,
+  );
+  document.getElementById("cors_trusted_origins").value = corsLines.join("\n");
+}
+
+function buildPayload() {
+  clearStatus();
+  clearValidationIndicators();
+  let failed = false;
+
+  function requiredText(id, label) {
+    const value = document.getElementById(id).value.trim();
+    if (!value) {
+      markFieldError(id, `${label} is required.`);
+      failed = true;
+    }
+    return value;
+  }
+
+  const payload = {
+    classifier_path: requiredText("classifier_path", "Classifier model path"),
+    predictive_path: requiredText("predictive_path", "Predictive model path"),
+    api_key: document.getElementById("api_key").value.trim() || null,
+    admin_api_key: document.getElementById("admin_api_key").value.trim() || null,
+    allow_anonymous: document.getElementById("allow_anonymous").checked,
+    license_public_key_path: document.getElementById("license_public_key_path").value.trim() || null,
+    license_public_key: document.getElementById("license_public_key").value.trim() || null,
+    license_algorithm: document.getElementById("license_algorithm").value.trim().toUpperCase(),
+    license_revoked_jtis: parseList("license_revoked_jtis"),
+    license_revoked_subjects: parseList("license_revoked_subjects"),
+  };
+
+  if (!payload.license_algorithm) {
+    markFieldError("license_algorithm", "License algorithm is required.");
+    failed = true;
+  }
+
+  const maxUpload = readIntField("max_upload_bytes", { required: true });
+  const maxText = readIntField("max_text_length", { required: true });
+  const maxFeatures = readIntField("max_feature_fields", { required: true });
+  const maxJson = readIntField("max_json_body_bytes", { required: false });
+  const ratePerMinute = readIntField("rate_limit_per_minute", { required: false });
+  const rateBurst = readIntField("rate_limit_burst", { required: false });
+
+  if (!maxUpload.ok || !maxText.ok || !maxFeatures.ok || !maxJson.ok || !ratePerMinute.ok || !rateBurst.ok) {
+    failed = true;
+  }
+
+  const corsValue = parseCorsOrigins(document.getElementById("cors_trusted_origins").value);
+  if (!corsValue.ok) {
+    markFieldError("cors_trusted_origins", corsValue.message || "Invalid CORS configuration.");
+    failed = true;
+  }
+
+  if (failed) {
+    return null;
+  }
+
+  payload.max_upload_bytes = maxUpload.value;
+  payload.max_text_length = maxText.value;
+  payload.max_feature_fields = maxFeatures.value;
+  payload.max_json_body_bytes = maxJson.value;
+  payload.rate_limit_per_minute = ratePerMinute.value;
+  payload.rate_limit_burst = rateBurst.value;
+  payload.cors_trusted_origins = corsValue.value;
+
+  return payload;
+}
+
+async function fetchSettings(showNotification = false) {
+  if (!adminToken) {
+    setAuthError("Enter the administrative token before loading settings.");
+    return;
+  }
+  clearAuthError();
+  setStatus("Loading settings…", "info");
+  loadButton.disabled = true;
+  if (refreshButton) {
+    refreshButton.disabled = true;
+  }
+  try {
+    const response = await fetch("/admin/settings", {
+      headers: {
+        "X-Admin-Token": adminToken,
+        Accept: "application/json",
+      },
+    });
+    if (response.status === 401) {
+      settingsCard.classList.add("hidden");
+      lastPayload = null;
+      setStatus("", "");
+      setAuthError("Admin token rejected. Verify the secret and try again.");
+      return;
+    }
+    if (response.status === 503) {
+      settingsCard.classList.add("hidden");
+      lastPayload = null;
+      setStatus("", "");
+      setAuthError("Administrative API is not enabled on this deployment.");
+      return;
+    }
+    if (!response.ok) {
+      const detail = await response.text();
+      setStatus(`Failed to load settings (${response.status}): ${detail}`, "error");
+      return;
+    }
+    const payload = await response.json();
+    populateForm(payload.values);
+    applyOverrides(payload.overrides);
+    settingsCard.classList.remove("hidden");
+    updateRememberStorage();
+    if (showNotification) {
+      setStatus("Settings refreshed.", "success");
+    } else {
+      setStatus("", "");
+    }
+  } catch (error) {
+    setStatus(`Unable to reach the server: ${error.message}`, "error");
+  } finally {
+    loadButton.disabled = false;
+    if (refreshButton) {
+      refreshButton.disabled = false;
+    }
+  }
+}
+
+async function submitSettings(event) {
+  event.preventDefault();
+  if (!adminToken) {
+    setAuthError("Enter the administrative token before saving settings.");
+    return;
+  }
+  const payload = buildPayload();
+  if (!payload) {
+    return;
+  }
+  clearAuthError();
+  setStatus("Saving changes…", "info");
+  const desiredAdminKey = payload.admin_api_key;
+  try {
+    const response = await fetch("/admin/settings", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Admin-Token": adminToken,
+      },
+      body: JSON.stringify(payload),
+    });
+    if (response.status === 401) {
+      setStatus("Save failed: admin token rejected.", "error");
+      settingsCard.classList.add("hidden");
+      setAuthError("Admin token rejected. Verify the secret and try again.");
+      return;
+    }
+    if (!response.ok) {
+      const detail = await response.text();
+      setStatus(`Save failed (${response.status}): ${detail}`, "error");
+      return;
+    }
+    const data = await response.json();
+    populateForm(data.values);
+    applyOverrides(data.overrides);
+    const effectiveAdminKey =
+      (desiredAdminKey && desiredAdminKey.trim()) ||
+      (data.values.admin_api_key && data.values.admin_api_key.trim()) ||
+      (data.values.api_key && data.values.api_key.trim()) ||
+      adminToken;
+    if (effectiveAdminKey) {
+      adminToken = effectiveAdminKey;
+      tokenInput.value = effectiveAdminKey;
+    }
+    updateRememberStorage();
+    setStatus("Settings saved successfully.", "success");
+  } catch (error) {
+    setStatus(`Save failed: ${error.message}`, "error");
+  }
+}
+
+function resetForm() {
+  if (lastPayload) {
+    populateForm(lastPayload);
+    applyOverrides(lastOverrides);
+    setStatus("Form reset to the last saved values.", "info");
+  } else {
+    form.reset();
+    applyOverrides({});
+    clearValidationIndicators();
+    setStatus("Form cleared.", "info");
+  }
+}
+
+loadButton.addEventListener("click", async () => {
+  const provided = tokenInput.value.trim();
+  if (!provided) {
+    setAuthError("Enter the administrative token before loading settings.");
+    return;
+  }
+  adminToken = provided;
+  await fetchSettings(true);
+});
+
+if (refreshButton) {
+  refreshButton.addEventListener("click", () => fetchSettings(true));
+}
+
+if (resetButton) {
+  resetButton.addEventListener("click", resetForm);
+}
+
+form.addEventListener("submit", submitSettings);
+rememberToggle.addEventListener("change", updateRememberStorage);
+
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "visible" && lastPayload) {
+    applyOverrides(lastOverrides);
+  }
+});
+
+initializeToken();

--- a/src/api/templates/admin.html
+++ b/src/api/templates/admin.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI Invoice Administration</title>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+    />
+    <link rel="stylesheet" href="/static/css/admin.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header">
+        <div>
+          <h1>AI Invoice Administration</h1>
+          <p class="subtitle">
+            Manage runtime configuration, authentication, and safety limits for the service.
+          </p>
+        </div>
+      </header>
+
+      <section class="card" id="authentication-card">
+        <h2>Authenticate</h2>
+        <p class="hint">
+          Enter the administrative token configured for the deployment. The token is stored locally only when you choose to remember it.
+        </p>
+        <div class="auth-grid">
+          <label for="admin-token" class="field-label">Admin token</label>
+          <input
+            type="password"
+            id="admin-token"
+            class="text-input"
+            autocomplete="off"
+            placeholder="X-Admin-Token"
+          />
+          <label class="remember-toggle">
+            <input type="checkbox" id="remember-token" />
+            <span>Remember this browser</span>
+          </label>
+          <button id="load-settings" type="button" class="primary">Load settings</button>
+        </div>
+        <p class="status-message error hidden" id="auth-error"></p>
+      </section>
+
+      <section class="card hidden" id="settings-card">
+        <div class="card-header">
+          <div>
+            <h2>Configuration</h2>
+            <p class="hint">
+              Fields flagged as “Environment override” reflect deploy-time values from environment variables. Updates are persisted but do not apply until the override is removed.
+            </p>
+          </div>
+          <div class="card-actions">
+            <button type="button" class="secondary" id="refresh-settings">Refresh</button>
+          </div>
+        </div>
+        <form id="settings-form">
+          <div class="form-section">
+            <h3>Model locations</h3>
+            <div class="form-grid">
+              <div class="form-row" data-field="classifier_path">
+                <label for="classifier_path">Classifier model path</label>
+                <input type="text" id="classifier_path" class="text-input" required />
+                <p class="hint">Filesystem path for the invoice classification model.</p>
+                <p class="override-note hidden" data-override="classifier_path">Environment override active.</p>
+              </div>
+              <div class="form-row" data-field="predictive_path">
+                <label for="predictive_path">Predictive model path</label>
+                <input type="text" id="predictive_path" class="text-input" required />
+                <p class="hint">Filesystem path for the payment prediction model.</p>
+                <p class="override-note hidden" data-override="predictive_path">Environment override active.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <h3>Authentication</h3>
+            <div class="form-grid">
+              <div class="form-row" data-field="api_key">
+                <label for="api_key">API key</label>
+                <input type="password" id="api_key" class="text-input" autocomplete="new-password" />
+                <p class="hint">Shared secret required in the <code>X-API-Key</code> header.</p>
+                <p class="override-note hidden" data-override="api_key">Environment override active.</p>
+              </div>
+              <div class="form-row" data-field="admin_api_key">
+                <label for="admin_api_key">Admin API key</label>
+                <input type="password" id="admin_api_key" class="text-input" autocomplete="new-password" />
+                <p class="hint">Secret required in the <code>X-Admin-Token</code> header for this portal and the admin API.</p>
+                <p class="override-note hidden" data-override="admin_api_key">Environment override active.</p>
+              </div>
+              <div class="form-row checkbox" data-field="allow_anonymous">
+                <label for="allow_anonymous">Allow anonymous access</label>
+                <input type="checkbox" id="allow_anonymous" />
+                <p class="hint">Permits requests without an API key. Avoid enabling in production.</p>
+                <p class="override-note hidden" data-override="allow_anonymous">Environment override active.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <h3>License</h3>
+            <div class="form-grid">
+              <div class="form-row" data-field="license_public_key_path">
+                <label for="license_public_key_path">License public key path</label>
+                <input type="text" id="license_public_key_path" class="text-input" />
+                <p class="hint">Path to an RSA/EC public key file. Leave blank to manage keys inline.</p>
+                <p class="override-note hidden" data-override="license_public_key_path">Environment override active.</p>
+              </div>
+              <div class="form-row" data-field="license_public_key">
+                <label for="license_public_key">Embedded license public key</label>
+                <textarea id="license_public_key" class="text-area" rows="6"></textarea>
+                <p class="hint">Paste the PEM-encoded public key when not using a file path.</p>
+                <p class="override-note hidden" data-override="license_public_key">Environment override active.</p>
+              </div>
+              <div class="form-row" data-field="license_algorithm">
+                <label for="license_algorithm">License algorithm</label>
+                <input type="text" id="license_algorithm" class="text-input" required />
+                <p class="hint">Algorithm used to verify license signatures (e.g., RS256).</p>
+                <p class="override-note hidden" data-override="license_algorithm">Environment override active.</p>
+              </div>
+              <div class="form-row" data-field="license_revoked_jtis">
+                <label for="license_revoked_jtis">Revoked token IDs</label>
+                <textarea id="license_revoked_jtis" class="text-area" rows="4" placeholder="jti-123&#10;jti-456"></textarea>
+                <p class="hint">One token ID per line. Leave blank to allow all issued tokens.</p>
+                <p class="override-note hidden" data-override="license_revoked_jtis">Environment override active.</p>
+              </div>
+              <div class="form-row" data-field="license_revoked_subjects">
+                <label for="license_revoked_subjects">Revoked subjects</label>
+                <textarea id="license_revoked_subjects" class="text-area" rows="4" placeholder="tenant-a&#10;tenant-b"></textarea>
+                <p class="hint">One subject per line to deny for all licenses.</p>
+                <p class="override-note hidden" data-override="license_revoked_subjects">Environment override active.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <h3>Request validation</h3>
+            <div class="form-grid">
+              <div class="form-row" data-field="max_upload_bytes">
+                <label for="max_upload_bytes">Max upload size (bytes)</label>
+                <input type="number" id="max_upload_bytes" class="text-input" min="0" step="1" required />
+                <p class="hint">Rejects uploaded files larger than the configured size.</p>
+                <p class="override-note hidden" data-override="max_upload_bytes">Environment override active.</p>
+              </div>
+              <div class="form-row" data-field="max_text_length">
+                <label for="max_text_length">Max text length</label>
+                <input type="number" id="max_text_length" class="text-input" min="0" step="1" required />
+                <p class="hint">Upper bound for characters processed by the classifier.</p>
+                <p class="override-note hidden" data-override="max_text_length">Environment override active.</p>
+              </div>
+              <div class="form-row" data-field="max_feature_fields">
+                <label for="max_feature_fields">Max feature fields</label>
+                <input type="number" id="max_feature_fields" class="text-input" min="0" step="1" required />
+                <p class="hint">Maximum keys accepted in the predictive features payload.</p>
+                <p class="override-note hidden" data-override="max_feature_fields">Environment override active.</p>
+              </div>
+              <div class="form-row" data-field="max_json_body_bytes">
+                <label for="max_json_body_bytes">Max JSON payload (bytes)</label>
+                <input type="number" id="max_json_body_bytes" class="text-input" min="0" step="1" />
+                <p class="hint">Optional ceiling for request bodies. Leave blank to disable.</p>
+                <p class="override-note hidden" data-override="max_json_body_bytes">Environment override active.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <h3>Rate limiting</h3>
+            <div class="form-grid">
+              <div class="form-row" data-field="rate_limit_per_minute">
+                <label for="rate_limit_per_minute">Requests per minute</label>
+                <input type="number" id="rate_limit_per_minute" class="text-input" min="0" step="1" />
+                <p class="hint">Optional steady-state throttle. Leave blank to disable.</p>
+                <p class="override-note hidden" data-override="rate_limit_per_minute">Environment override active.</p>
+              </div>
+              <div class="form-row" data-field="rate_limit_burst">
+                <label for="rate_limit_burst">Burst allowance</label>
+                <input type="number" id="rate_limit_burst" class="text-input" min="0" step="1" />
+                <p class="hint">Extra burst tokens beyond the per-minute rate.</p>
+                <p class="override-note hidden" data-override="rate_limit_burst">Environment override active.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <h3>CORS policy</h3>
+            <div class="form-grid">
+              <div class="form-row" data-field="cors_trusted_origins">
+                <label for="cors_trusted_origins">Trusted origins</label>
+                <textarea
+                  id="cors_trusted_origins"
+                  class="text-area"
+                  rows="5"
+                  placeholder="https://app.example.com|true&#10;https://portal.example.com"
+                ></textarea>
+                <p class="hint">
+                  One origin per line. Append <code>|true</code> to require credentials. Use <code>*</code> for all origins (without credentials).
+                </p>
+                <p class="override-note hidden" data-override="cors_trusted_origins">Environment override active.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-actions">
+            <button type="submit" class="primary">Save changes</button>
+            <button type="button" class="secondary" id="reset-form">Reset</button>
+          </div>
+          <p class="status-message" id="status-message"></p>
+        </form>
+      </section>
+    </div>
+    <script type="module" src="/static/js/admin.js"></script>
+  </body>
+</html>

--- a/tests/test_license_validator.py
+++ b/tests/test_license_validator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
@@ -16,6 +17,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_DIR = PROJECT_ROOT / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
+
+os.environ.setdefault("API_KEY", "test-secret")
 
 from ai_invoice.config import settings
 from api.security import reset_license_verifier_cache, require_license_token

--- a/tests/test_settings_admin.py
+++ b/tests/test_settings_admin.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("API_KEY", "pytest-default-key")
+
+from ai_invoice import config
+from api.routers import admin
+
+
+def test_settings_persistence_with_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store_path = tmp_path / "settings.json"
+    monkeypatch.setenv("AI_INVOICE_SETTINGS_PATH", str(store_path))
+    monkeypatch.setenv("AI_API_KEY", "unit-api-key")
+    config.reload_settings()
+
+    assert config.settings.max_upload_bytes == 5 * 1024 * 1024
+    config.update_persisted_settings({"max_upload_bytes": 123456})
+    assert config.settings.max_upload_bytes == 123456
+
+    persisted = json.loads(store_path.read_text(encoding="utf-8"))
+    assert persisted["max_upload_bytes"] == 123456
+
+    # Environment overrides take precedence but do not replace persisted values
+    monkeypatch.setenv("MAX_UPLOAD_BYTES", "999")
+    reloaded = config.reload_settings()
+    assert reloaded.max_upload_bytes == 999
+    overrides = config.get_environment_overrides()
+    assert overrides["max_upload_bytes"] is True
+
+    monkeypatch.delenv("MAX_UPLOAD_BYTES", raising=False)
+    config.reload_settings()
+    assert config.settings.max_upload_bytes == 123456
+
+    # Restore baseline configuration for subsequent tests
+    monkeypatch.delenv("AI_INVOICE_SETTINGS_PATH", raising=False)
+    monkeypatch.setenv("AI_API_KEY", "pytest-default-key")
+    config.reload_settings()
+
+
+def test_admin_endpoints_apply_updates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store_path = tmp_path / "settings.json"
+    monkeypatch.setenv("AI_INVOICE_SETTINGS_PATH", str(store_path))
+    monkeypatch.setenv("AI_API_KEY", "integration-api-key")
+    config.reload_settings()
+
+    # Ensure authentication accepts the configured admin token
+    admin.require_admin_token(x_admin_token="integration-api-key")
+
+    envelope = admin.read_settings()
+    assert envelope.values.api_key == "integration-api-key"
+
+    updated_model = envelope.values.model_copy()
+    updated_model.max_upload_bytes = 654321
+    updated_model.cors_trusted_origins = [
+        admin.CorsOriginModel(origin="https://unit.test", allow_credentials=False)
+    ]
+    updated_model.license_algorithm = "RS512"
+    updated_model.admin_api_key = "rotated-admin"
+
+    result = admin.update_settings(updated_model)
+    assert result.values.max_upload_bytes == 654321
+    assert result.values.admin_api_key == "rotated-admin"
+
+    # Old token should no longer be accepted
+    with pytest.raises(HTTPException):
+        admin.require_admin_token(x_admin_token="integration-api-key")
+
+    admin.require_admin_token(x_admin_token="rotated-admin")
+    refreshed = admin.read_settings()
+    assert refreshed.values.max_upload_bytes == 654321
+
+    persisted = json.loads(store_path.read_text(encoding="utf-8"))
+    assert persisted["max_upload_bytes"] == 654321
+    assert persisted["admin_api_key"] == "rotated-admin"
+
+    # Reset to shared defaults so other tests see expected values
+    monkeypatch.delenv("AI_INVOICE_SETTINGS_PATH", raising=False)
+    monkeypatch.setenv("AI_API_KEY", "pytest-default-key")
+    config.reload_settings()


### PR DESCRIPTION
## Summary
- add a JSON-backed settings store and update configuration loading to merge persisted values with environment overrides
- expose authenticated `/admin/settings` APIs and a static admin portal for viewing and editing configuration
- document the new workflow and refresh the example environment settings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d371d0373883298007845321ea7357