### PR TITLE
Add web portal for manual invoice operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ This repository contains a cross-platform AI service (Python/FastAPI) and Window
    curl -H "X-API-Key: $AI_API_KEY" -H "Content-Type: application/json" -d '{"features":{"amount":950,"customer_age_days":400,"prior_invoices":12,"late_ratio":0.2,"weekday":2,"month":9}}' http://localhost:8088/predict
 ````
 
-5. (Optional) Interact with the classifier management endpoints:
+5. Open the interactive portal at [http://localhost:8088/portal](http://localhost:8088/portal) to upload invoices, classify text, and score predictions from the browser. The UI surfaces validation errors (401/403/413) directly and can optionally remember your API key/license token. See [docs/invoice_portal.md](docs/invoice_portal.md) for a guided tour.
+
+6. (Optional) Interact with the classifier management endpoints:
 
 ````bash
    curl -H "X-API-Key: $AI_API_KEY" http://localhost:8088/models/classifier/status

--- a/docs/invoice_portal.md
+++ b/docs/invoice_portal.md
@@ -1,0 +1,65 @@
+# Invoice Operations Portal
+
+The invoice portal is a FastAPI-powered workspace that bundles the most common invoice operations into a single, client-side experience. It lives alongside the existing admin console and is ideal for manual testing, demos, and troubleshooting.
+
+## Launching the portal
+
+1. Configure and run the API service as described in the project README. In development you can launch the server with:
+
+   ```bash
+   uv run uvicorn api.main:app --reload --port 8088
+   ```
+
+2. Navigate to [http://localhost:8088/portal](http://localhost:8088/portal) in a modern browser.
+
+   The UI is entirely client-side and communicates with the FastAPI endpoints that already power automated workflows.
+
+## Authentication and licensing
+
+The portal uses the same security middleware as the REST API:
+
+- **X-API-Key** – required on every non-health request when `API_KEY` (or `AI_API_KEY`) is configured. Enter the key in the *Authentication* card. You can optionally store the value in `localStorage` by ticking **“Remember these secrets on this device”**.
+- **X-License-Token** – required when license enforcement is enabled. Paste a signed token containing the necessary feature flags. The UI never persists the token unless you opt in.
+
+If you do not enable the “remember” toggle the secrets stay in memory for the duration of the tab only. Clearing the toggle immediately wipes any stored values.
+
+### Feature flags
+
+Each invoice workflow requires a dedicated feature flag to be present in the license token:
+
+| Feature flag | Enables |
+| --- | --- |
+| `extract` | Uploading files to `/invoices/extract` for OCR + field parsing. |
+| `classify` | Sending text payloads to `/invoices/classify`. |
+| `predict` | Scoring feature vectors via `/invoices/predict` or `/predict`. |
+
+If the token is missing a feature you will receive an HTTP 403 with an explanatory message. HTTP 401 responses usually indicate a missing or invalid API key or license signature.
+
+## Available workflows
+
+### Invoice extraction
+
+- Drag-and-drop a PDF, PNG, or JPEG into the drop zone (or browse for a file).
+- Click **Extract invoice** to call `POST /invoices/extract`.
+- Successful responses show normalized header fields, totals, line items, and the captured raw text. Validation errors (empty file, max upload bytes) surface inline with a red banner.
+
+### Text classification
+
+- Paste unstructured invoice text into the editor and submit the form.
+- The UI issues `POST /invoices/classify` and displays the predicted label alongside the probability score.
+- Exceeding the configured length limit or submitting empty text returns a 400/413 response that is rendered in the results panel.
+
+### Payment prediction
+
+- Use the feature table to define key/value pairs for predictive scoring. Add or remove rows as needed; blank rows are ignored.
+- Select either the canonical `/invoices/predict` endpoint or the `/predict` alias.
+- The payload is POSTed as JSON (`{"features": {...}}`). The portal automatically coerces numeric and boolean literals when possible and prints the resulting prediction, risk score, and confidence.
+
+## Troubleshooting
+
+- **413 Payload Too Large** – Increase `MAX_UPLOAD_BYTES` (files) or `MAX_JSON_BODY_BYTES`/`MAX_TEXT_LENGTH` (JSON/text) in your configuration, or submit smaller inputs.
+- **401/403 Unauthorized** – Confirm the API key and license token match the service configuration. Token claims must include the required feature flag(s).
+- **429 Too Many Requests** – The middleware enforces rate limiting when configured. Reduce request frequency or adjust `RATE_LIMIT_PER_MINUTE`/`RATE_LIMIT_BURST`.
+- **Unexpected errors** – Network failures and JSON parsing issues are surfaced inline. Use browser developer tools for deeper inspection and review server logs for stack traces.
+
+The portal enhances (but does not replace) automated integration tests. It is designed to be safe to host in trusted environments where direct API access is appropriate.

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -64,7 +64,14 @@ def root() -> dict[str, str]:
 
 @app.get("/admin", response_class=HTMLResponse)
 def admin_portal(request: Request) -> HTMLResponse:
-    return _TEMPLATES.TemplateResponse("admin.html", {"request": request})
+    return _TEMPLATES.TemplateResponse(request, "admin.html", {"request": request})
+
+
+@app.get("/portal", response_class=HTMLResponse)
+def invoice_portal(request: Request) -> HTMLResponse:
+    """Render the interactive workspace for invoice operations."""
+
+    return _TEMPLATES.TemplateResponse(request, "invoice_portal.html", {"request": request})
 
 
 @app.post("/predict", response_model=PredictiveResult, tags=["invoices"])

--- a/src/api/static/css/invoice_portal.css
+++ b/src/api/static/css/invoice_portal.css
@@ -1,0 +1,539 @@
+:root {
+  color-scheme: light;
+  --color-background: #f5f7fb;
+  --color-surface: #ffffff;
+  --color-border: #d7deea;
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-primary-soft: rgba(37, 99, 235, 0.1);
+  --color-text: #1f2937;
+  --color-muted: #6b7280;
+  --color-success: #0f766e;
+  --color-danger: #dc2626;
+  --shadow-soft: 0 12px 30px rgba(15, 23, 42, 0.08);
+  --radius-large: 18px;
+  --radius-medium: 12px;
+  --radius-small: 8px;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f9fbff 0%, #eef2f9 100%);
+  color: var(--color-text);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.page-header {
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.12), transparent 55%),
+    linear-gradient(135deg, #0f172a, #1d4ed8);
+  color: #f8fafc;
+  padding: 56px 24px 48px;
+  text-align: center;
+  box-shadow: var(--shadow-soft);
+  border-bottom-left-radius: var(--radius-large);
+  border-bottom-right-radius: var(--radius-large);
+}
+
+.page-header__content {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.page-header__subtitle {
+  margin: 12px auto 24px;
+  max-width: 680px;
+  font-size: 1.05rem;
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.page-header__links {
+  display: flex;
+  justify-content: center;
+  gap: 18px;
+}
+
+.page-header__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background-color: rgba(15, 23, 42, 0.35);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  transition: background-color 150ms ease, transform 150ms ease;
+}
+
+.page-header__link:hover,
+.page-header__link:focus {
+  background-color: rgba(37, 99, 235, 0.5);
+  transform: translateY(-1px);
+}
+
+.portal {
+  max-width: 1100px;
+  margin: -48px auto 64px;
+  padding: 0 24px 64px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 32px;
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: var(--radius-large);
+  padding: 28px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.card__lead {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.form-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.form-grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: end;
+  gap: 16px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.form-field input,
+.form-field textarea,
+.form-field select {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-small);
+  padding: 10px 14px;
+  font-size: 0.95rem;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+  background: #fff;
+}
+
+.form-field input:focus,
+.form-field textarea:focus,
+.form-field select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-soft);
+}
+
+.form-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.form-checkbox input {
+  width: 18px;
+  height: 18px;
+}
+
+.form-helper {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.form-actions--end {
+  justify-content: flex-end;
+}
+
+.button {
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, background-color 120ms ease;
+  border: 1px solid transparent;
+}
+
+.button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.button--primary {
+  background: var(--color-primary);
+  color: #fff;
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.25);
+}
+
+.button--primary:hover,
+.button--primary:focus {
+  background: var(--color-primary-hover);
+  transform: translateY(-1px);
+}
+
+.button--outline {
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid var(--color-border);
+  color: var(--color-primary);
+}
+
+.button--outline:hover,
+.button--outline:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-soft);
+}
+
+.button--ghost {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-primary);
+  border: 1px dashed rgba(37, 99, 235, 0.3);
+}
+
+.button--ghost:hover,
+.button--ghost:focus {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.button--icon {
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.05);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.button--icon:hover,
+.button--icon:focus {
+  background: rgba(220, 38, 38, 0.1);
+  color: var(--color-danger);
+  border-color: rgba(220, 38, 38, 0.25);
+}
+
+textarea {
+  resize: vertical;
+  min-height: 160px;
+}
+
+.drop-zone {
+  position: relative;
+  border: 2px dashed rgba(37, 99, 235, 0.35);
+  border-radius: var(--radius-medium);
+  padding: 28px 18px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  background: rgba(37, 99, 235, 0.06);
+  transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
+}
+
+.drop-zone.is-dragover {
+  border-color: var(--color-primary);
+  background: rgba(37, 99, 235, 0.14);
+  transform: translateY(-2px);
+}
+
+.drop-zone__hint strong {
+  display: block;
+  font-size: 1rem;
+  margin-bottom: 4px;
+}
+
+.drop-zone input[type='file'] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.drop-zone__file {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.feature-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-primary);
+  background: rgba(37, 99, 235, 0.12);
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+.feature-table-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.feature-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  border-radius: var(--radius-medium);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.03);
+}
+
+.feature-table th,
+.feature-table td {
+  padding: 12px 14px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.05);
+  text-align: left;
+  background: #fff;
+}
+
+.feature-table tbody tr:last-of-type td {
+  border-bottom: none;
+}
+
+.feature-row.has-error input {
+  border-color: var(--color-danger);
+  box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.2);
+}
+
+.loading {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.loading::before {
+  content: '';
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.6);
+  border-top-color: var(--color-primary);
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.results {
+  background: rgba(15, 23, 42, 0.03);
+  border-radius: var(--radius-medium);
+  padding: 20px;
+  min-height: 60px;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.results:empty {
+  display: none;
+}
+
+.results.has-error {
+  border-color: rgba(220, 38, 38, 0.25);
+  background: rgba(254, 226, 226, 0.55);
+}
+
+.results details {
+  margin-top: 12px;
+}
+
+.results details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.results pre {
+  margin: 12px 0 0;
+  background: #fff;
+  border-radius: var(--radius-small);
+  padding: 12px;
+  max-height: 260px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.result-card h3,
+.result-card h4 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.result-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px 24px;
+}
+
+.result-grid dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.result-grid dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.result-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-small);
+  overflow: hidden;
+}
+
+.result-table th,
+.result-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.05);
+  text-align: left;
+}
+
+.result-table tbody tr:nth-child(odd) {
+  background: rgba(15, 23, 42, 0.03);
+}
+
+.result-meta {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  margin-top: 12px;
+}
+
+.error-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--color-danger);
+  font-weight: 600;
+}
+
+.error-banner__detail {
+  font-weight: 400;
+}
+
+code {
+  font-family: 'Fira Code', 'SFMono-Regular', Menlo, Consolas, monospace;
+  background: rgba(15, 23, 42, 0.08);
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+.muted {
+  color: var(--color-muted);
+}
+
+@media (max-width: 768px) {
+  .portal {
+    margin-top: -32px;
+    grid-template-columns: 1fr;
+  }
+
+  .card {
+    padding: 22px;
+  }
+
+  .form-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .form-actions--end {
+    align-items: stretch;
+  }
+
+  .button--primary,
+  .button--outline {
+    width: 100%;
+  }
+
+  .feature-table__actions {
+    text-align: right;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/api/static/js/invoice_portal.js
+++ b/src/api/static/js/invoice_portal.js
@@ -1,0 +1,653 @@
+class ApiError extends Error {
+  constructor(status, message, payload) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.payload = payload;
+  }
+}
+
+const STORAGE_KEY = 'ai-invoice-portal.credentials';
+
+const elements = {
+  apiKey: document.getElementById('api-key'),
+  licenseToken: document.getElementById('license-token'),
+  rememberSecrets: document.getElementById('remember-secrets'),
+  extract: {
+    form: document.getElementById('extract-form'),
+    fileInput: document.getElementById('extract-file'),
+    fileName: document.getElementById('extract-file-name'),
+    trigger: document.getElementById('extract-file-button'),
+    dropZone: document.getElementById('extract-drop-zone'),
+    submit: document.getElementById('extract-submit'),
+    loading: document.getElementById('extract-loading'),
+    result: document.getElementById('extract-result'),
+  },
+  classify: {
+    form: document.getElementById('classify-form'),
+    text: document.getElementById('classify-text'),
+    submit: document.getElementById('classify-submit'),
+    loading: document.getElementById('classify-loading'),
+    result: document.getElementById('classify-result'),
+  },
+  predict: {
+    form: document.getElementById('predict-form'),
+    tableBody: document.getElementById('feature-rows'),
+    template: document.getElementById('feature-row-template'),
+    addRow: document.getElementById('add-feature-row'),
+    endpoint: document.getElementById('predict-endpoint'),
+    submit: document.getElementById('predict-submit'),
+    loading: document.getElementById('predict-loading'),
+    result: document.getElementById('predict-result'),
+  },
+};
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function muted(text = '—') {
+  return `<span class="muted">${escapeHtml(text)}</span>`;
+}
+
+function normaliseErrorDetail(detail) {
+  if (detail == null) {
+    return 'Unexpected error.';
+  }
+  if (typeof detail === 'string') {
+    return detail;
+  }
+  if (Array.isArray(detail)) {
+    return detail
+      .map((item) => normaliseErrorDetail(item))
+      .filter(Boolean)
+      .join('\n');
+  }
+  if (typeof detail === 'object') {
+    if (Object.prototype.hasOwnProperty.call(detail, 'detail')) {
+      return normaliseErrorDetail(detail.detail);
+    }
+    if (Object.prototype.hasOwnProperty.call(detail, 'message')) {
+      return normaliseErrorDetail(detail.message);
+    }
+    if (Object.prototype.hasOwnProperty.call(detail, 'msg')) {
+      const prefix = Array.isArray(detail.loc) ? `${detail.loc.join('.')}: ` : '';
+      return `${prefix}${detail.msg}`;
+    }
+    try {
+      return JSON.stringify(detail, null, 2);
+    } catch (error) {
+      return String(detail);
+    }
+  }
+  return String(detail);
+}
+
+async function sendRequest(url, { method = 'GET', headers = new Headers(), body = undefined } = {}) {
+  const response = await fetch(url, { method, headers, body });
+  const contentType = response.headers.get('Content-Type') || '';
+  const isJson = contentType.includes('application/json');
+  let payload;
+  try {
+    payload = isJson ? await response.json() : await response.text();
+  } catch (error) {
+    payload = isJson ? {} : '';
+  }
+
+  if (!response.ok) {
+    const detail = normaliseErrorDetail(payload);
+    throw new ApiError(response.status, detail, payload);
+  }
+
+  return payload;
+}
+
+function readCredentials() {
+  return {
+    apiKey: elements.apiKey?.value.trim() ?? '',
+    licenseToken: elements.licenseToken?.value.trim() ?? '',
+  };
+}
+
+function buildHeaders(additional = {}) {
+  const headers = new Headers();
+  Object.entries(additional).forEach(([key, value]) => {
+    if (value != null) {
+      headers.set(key, value);
+    }
+  });
+  const { apiKey, licenseToken } = readCredentials();
+  if (apiKey) {
+    headers.set('X-API-Key', apiKey);
+  }
+  if (licenseToken) {
+    headers.set('X-License-Token', licenseToken);
+  }
+  return headers;
+}
+
+function safeStorage(action, key, value) {
+  try {
+    if (!window.localStorage) {
+      return null;
+    }
+  } catch (error) {
+    return null;
+  }
+
+  try {
+    if (action === 'get') {
+      return window.localStorage.getItem(key);
+    }
+    if (action === 'set') {
+      window.localStorage.setItem(key, value ?? '');
+    }
+    if (action === 'remove') {
+      window.localStorage.removeItem(key);
+    }
+  } catch (error) {
+    console.warn('Unable to access localStorage', error);
+  }
+  return null;
+}
+
+function persistCredentialsIfNeeded() {
+  if (!elements.rememberSecrets) {
+    return;
+  }
+  if (!elements.rememberSecrets.checked) {
+    safeStorage('remove', STORAGE_KEY);
+    return;
+  }
+  const credentials = readCredentials();
+  const serialised = JSON.stringify(credentials);
+  safeStorage('set', STORAGE_KEY, serialised);
+}
+
+function restoreCredentials() {
+  const stored = safeStorage('get', STORAGE_KEY);
+  if (!stored) {
+    return;
+  }
+  try {
+    const credentials = JSON.parse(stored);
+    if (credentials.apiKey && elements.apiKey) {
+      elements.apiKey.value = credentials.apiKey;
+    }
+    if (credentials.licenseToken && elements.licenseToken) {
+      elements.licenseToken.value = credentials.licenseToken;
+    }
+    if (elements.rememberSecrets) {
+      elements.rememberSecrets.checked = true;
+    }
+  } catch (error) {
+    console.warn('Stored credentials could not be parsed', error);
+  }
+}
+
+function setLoading(button, indicator, busy) {
+  if (!button || !indicator) {
+    return;
+  }
+  button.disabled = busy;
+  indicator.hidden = !busy;
+  button.setAttribute('aria-busy', String(busy));
+}
+
+function clearResult(container) {
+  if (!container) {
+    return;
+  }
+  container.innerHTML = '';
+  container.classList.remove('has-error');
+}
+
+function setResult(container, html, isError = false) {
+  if (!container) {
+    return;
+  }
+  container.innerHTML = html;
+  container.classList.toggle('has-error', isError);
+}
+
+function renderError(container, message, status) {
+  const statusLabel = status ? `Request failed (HTTP ${status})` : 'Request failed';
+  const detail = escapeHtml(message);
+  setResult(
+    container,
+    `<div class="error-banner"><span>${statusLabel}</span><span class="error-banner__detail">${detail}</span></div>`,
+    true,
+  );
+}
+
+function formatValue(value) {
+  if (value === null || value === undefined || value === '') {
+    return muted();
+  }
+  if (typeof value === 'number') {
+    return escapeHtml(value.toLocaleString(undefined, { maximumFractionDigits: 4 }));
+  }
+  return escapeHtml(String(value));
+}
+
+function formatNumber(value, decimals = 2) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) {
+    return muted();
+  }
+  const number = Number(value);
+  return escapeHtml(
+    number.toLocaleString(undefined, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    }),
+  );
+}
+
+function formatProbability(value) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) {
+    return muted();
+  }
+  const number = Number(value);
+  const percent = number * 100;
+  return escapeHtml(
+    percent.toLocaleString(undefined, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 2,
+    }) + '%',
+  );
+}
+
+function renderExtraction(result) {
+  const container = elements.extract.result;
+  const fields = [
+    ['Supplier name', result.supplier_name],
+    ['Supplier tax ID', result.supplier_tax_id],
+    ['Invoice number', result.invoice_number],
+    ['Invoice date', result.invoice_date],
+    ['Due date', result.due_date],
+    ['Buyer name', result.buyer_name],
+    ['Buyer tax ID', result.buyer_tax_id],
+    ['Currency', result.currency],
+    ['Subtotal', result.subtotal],
+    ['Tax', result.tax],
+    ['Total', result.total],
+  ];
+
+  let html = '<div class="result-card">';
+  html += '<h3>Extracted fields</h3>';
+  html += '<dl class="result-grid">';
+  fields.forEach(([label, value]) => {
+    html += `<dt>${escapeHtml(label)}</dt><dd>${formatValue(value)}</dd>`;
+  });
+  html += '</dl>';
+
+  if (Array.isArray(result.items) && result.items.length > 0) {
+    html += '<h4>Line items</h4>';
+    html += '<table class="result-table"><thead><tr><th>Description</th><th>Qty</th><th>Unit price</th><th>Total</th></tr></thead><tbody>';
+    result.items.forEach((item) => {
+      html += '<tr>';
+      html += `<td>${formatValue(item.description)}</td>`;
+      html += `<td>${formatValue(item.quantity)}</td>`;
+      html += `<td>${formatValue(item.unit_price)}</td>`;
+      html += `<td>${formatValue(item.total)}</td>`;
+      html += '</tr>';
+    });
+    html += '</tbody></table>';
+  }
+
+  if (result.raw_text) {
+    html += `<details class="result-meta" open><summary>Raw text</summary><pre>${escapeHtml(result.raw_text)}</pre></details>`;
+  }
+
+  html += '</div>';
+  setResult(container, html);
+}
+
+function renderClassification(result) {
+  const container = elements.classify.result;
+  const html = `
+    <div class="result-card">
+      <h3>Classification result</h3>
+      <dl class="result-grid">
+        <dt>Label</dt><dd>${formatValue(result.label)}</dd>
+        <dt>Probability</dt><dd>${formatProbability(result.proba)}</dd>
+      </dl>
+    </div>
+  `;
+  setResult(container, html);
+}
+
+function renderPrediction(result) {
+  const container = elements.predict.result;
+  const html = `
+    <div class="result-card">
+      <h3>Predicted payment</h3>
+      <dl class="result-grid">
+        <dt>Expected days to pay</dt><dd>${formatNumber(result.predicted_payment_days, 1)}</dd>
+        <dt>Projected payment date</dt><dd>${formatValue(result.predicted_payment_date)}</dd>
+        <dt>Risk score</dt><dd>${formatNumber(result.risk_score, 3)}</dd>
+        <dt>Confidence</dt><dd>${formatProbability(result.confidence)}</dd>
+      </dl>
+    </div>
+  `;
+  setResult(container, html);
+}
+
+function parseFeatureValue(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.toLowerCase() === 'true') {
+    return true;
+  }
+  if (trimmed.toLowerCase() === 'false') {
+    return false;
+  }
+  const numeric = Number(trimmed);
+  if (!Number.isNaN(numeric)) {
+    return numeric;
+  }
+  return value;
+}
+
+function collectFeatures() {
+  const rows = Array.from(elements.predict.tableBody?.querySelectorAll('.feature-row') ?? []);
+  const features = {};
+  let hasError = false;
+
+  rows.forEach((row) => {
+    row.classList.remove('has-error');
+    const keyInput = row.querySelector('.feature-key');
+    const valueInput = row.querySelector('.feature-value');
+    const key = keyInput?.value.trim() ?? '';
+    const value = valueInput?.value ?? '';
+
+    if (!key && !value) {
+      return; // skip empty rows
+    }
+    if (!key) {
+      row.classList.add('has-error');
+      hasError = true;
+      return;
+    }
+    features[key] = parseFeatureValue(value);
+  });
+
+  return { features, hasError };
+}
+
+function ensureMinimumRows() {
+  const rows = elements.predict.tableBody?.querySelectorAll('.feature-row');
+  if (!rows || rows.length > 0) {
+    return;
+  }
+  addFeatureRow();
+}
+
+function addFeatureRow(key = '', value = '') {
+  const template = elements.predict.template;
+  const tbody = elements.predict.tableBody;
+  if (!template || !tbody) {
+    return;
+  }
+  const prototypeRow = template.content.firstElementChild;
+  if (!prototypeRow) {
+    return;
+  }
+  const fragment = prototypeRow.cloneNode(true);
+  const keyInput = fragment.querySelector('.feature-key');
+  const valueInput = fragment.querySelector('.feature-value');
+  const removeButton = fragment.querySelector('.remove-feature');
+
+  if (keyInput) {
+    keyInput.value = key;
+  }
+  if (valueInput) {
+    valueInput.value = value;
+  }
+  if (removeButton) {
+    removeButton.addEventListener('click', () => {
+      fragment.remove();
+      ensureMinimumRows();
+    });
+  }
+
+  tbody.appendChild(fragment);
+}
+
+function updateFileNameLabel() {
+  const { fileInput, fileName } = elements.extract;
+  if (!fileInput || !fileName) {
+    return;
+  }
+  const file = fileInput.files && fileInput.files[0];
+  fileName.textContent = file ? file.name : 'No file selected';
+}
+
+function setupDropZone() {
+  const { dropZone, fileInput } = elements.extract;
+  if (!dropZone || !fileInput) {
+    return;
+  }
+  dropZone.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    dropZone.classList.add('is-dragover');
+  });
+  dropZone.addEventListener('dragleave', () => {
+    dropZone.classList.remove('is-dragover');
+  });
+  dropZone.addEventListener('drop', (event) => {
+    event.preventDefault();
+    dropZone.classList.remove('is-dragover');
+    const files = event.dataTransfer?.files;
+    if (!files || files.length === 0) {
+      return;
+    }
+    const file = files[0];
+    let assigned = false;
+    if (typeof DataTransfer !== 'undefined') {
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      fileInput.files = dataTransfer.files;
+      assigned = true;
+    }
+    if (!assigned) {
+      try {
+        fileInput.files = files;
+        assigned = true;
+      } catch (error) {
+        console.warn('Unable to populate file input from drop event', error);
+      }
+    }
+    if (!assigned) {
+      fileInput.value = '';
+    }
+    updateFileNameLabel();
+  });
+}
+
+function bindCredentialPersistence() {
+  if (!elements.rememberSecrets) {
+    return;
+  }
+  elements.rememberSecrets.addEventListener('change', () => {
+    if (!elements.rememberSecrets.checked) {
+      safeStorage('remove', STORAGE_KEY);
+    } else {
+      persistCredentialsIfNeeded();
+    }
+  });
+  [elements.apiKey, elements.licenseToken].forEach((input) => {
+    if (!input) {
+      return;
+    }
+    input.addEventListener('input', () => {
+      if (elements.rememberSecrets?.checked) {
+        persistCredentialsIfNeeded();
+      }
+    });
+  });
+}
+
+function bindExtractForm() {
+  const { form, submit, loading, result, fileInput, trigger } = elements.extract;
+  if (!form || !submit || !loading || !result || !fileInput) {
+    return;
+  }
+
+  if (trigger) {
+    trigger.addEventListener('click', () => fileInput.click());
+  }
+
+  fileInput.addEventListener('change', updateFileNameLabel);
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    clearResult(result);
+
+    const file = fileInput.files && fileInput.files[0];
+    if (!file) {
+      renderError(result, 'Select an invoice file before submitting.', 400);
+      return;
+    }
+
+    persistCredentialsIfNeeded();
+    setLoading(submit, loading, true);
+    const headers = buildHeaders();
+    const formData = new FormData();
+    formData.append('file', file);
+
+    try {
+      const payload = await sendRequest('/invoices/extract', {
+        method: 'POST',
+        headers,
+        body: formData,
+      });
+      renderExtraction(payload);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        renderError(result, error.message, error.status);
+      } else {
+        renderError(result, error?.message ?? 'Unexpected network error.', undefined);
+      }
+    } finally {
+      setLoading(submit, loading, false);
+    }
+  });
+}
+
+function bindClassifyForm() {
+  const { form, submit, loading, result, text } = elements.classify;
+  if (!form || !submit || !loading || !result || !text) {
+    return;
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    clearResult(result);
+
+    const content = text.value.trim();
+    if (!content) {
+      renderError(result, 'Provide text to classify.', 400);
+      return;
+    }
+
+    persistCredentialsIfNeeded();
+    setLoading(submit, loading, true);
+    const headers = buildHeaders({ 'Content-Type': 'application/json' });
+
+    try {
+      const payload = await sendRequest('/invoices/classify', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ text: content }),
+      });
+      renderClassification(payload);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        renderError(result, error.message, error.status);
+      } else {
+        renderError(result, error?.message ?? 'Unexpected network error.', undefined);
+      }
+    } finally {
+      setLoading(submit, loading, false);
+    }
+  });
+}
+
+function bindPredictForm() {
+  const { form, submit, loading, result, addRow, endpoint } = elements.predict;
+  if (!form || !submit || !loading || !result || !addRow || !endpoint) {
+    return;
+  }
+
+  addRow.addEventListener('click', () => addFeatureRow());
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    clearResult(result);
+
+    const { features, hasError } = collectFeatures();
+    if (hasError) {
+      renderError(result, 'Each populated row must include a feature key.', 400);
+      return;
+    }
+    if (Object.keys(features).length === 0) {
+      renderError(result, 'Add at least one feature before scoring.', 400);
+      return;
+    }
+
+    persistCredentialsIfNeeded();
+    setLoading(submit, loading, true);
+    const headers = buildHeaders({ 'Content-Type': 'application/json' });
+    const target = endpoint.value || '/invoices/predict';
+
+    try {
+      const payload = await sendRequest(target, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ features }),
+      });
+      renderPrediction(payload);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        renderError(result, error.message, error.status);
+      } else {
+        renderError(result, error?.message ?? 'Unexpected network error.', undefined);
+      }
+    } finally {
+      setLoading(submit, loading, false);
+    }
+  });
+}
+
+function initialisePredictTable() {
+  const sampleRows = [
+    ['amount', '950'],
+    ['customer_age_days', '400'],
+    ['prior_invoices', '12'],
+    ['late_ratio', '0.2'],
+  ];
+  sampleRows.forEach(([key, value]) => addFeatureRow(key, value));
+}
+
+function init() {
+  restoreCredentials();
+  bindCredentialPersistence();
+  bindExtractForm();
+  bindClassifyForm();
+  bindPredictForm();
+  setupDropZone();
+  initialisePredictTable();
+}
+
+init();

--- a/src/api/templates/invoice_portal.html
+++ b/src/api/templates/invoice_portal.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Invoice Operations Portal</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='css/invoice_portal.css') }}" />
+  </head>
+  <body>
+    <header class="page-header">
+      <div class="page-header__content">
+        <h1>Invoice Operations Portal</h1>
+        <p class="page-header__subtitle">
+          Upload invoices, classify raw text, and score payment predictions with your licensed features.
+        </p>
+        <nav class="page-header__links">
+          <a href="/" class="page-header__link">API Root</a>
+          <a href="/admin" class="page-header__link">Admin Console</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="portal" id="invoice-portal">
+      <section class="card" id="credentials">
+        <h2>Authentication</h2>
+        <p class="card__lead">
+          Provide the secrets required by <code>X-API-Key</code> authentication and the optional
+          <code>X-License-Token</code> for licensed features.
+        </p>
+        <form class="form-grid" id="credentials-form">
+          <label class="form-field">
+            <span class="form-label">X-API-Key</span>
+            <input type="password" id="api-key" autocomplete="off" placeholder="Enter your API key" />
+          </label>
+          <label class="form-field">
+            <span class="form-label">X-License-Token</span>
+            <input
+              type="password"
+              id="license-token"
+              autocomplete="off"
+              placeholder="Paste your signed license token"
+            />
+          </label>
+          <label class="form-checkbox">
+            <input type="checkbox" id="remember-secrets" />
+            <span>Remember these secrets on this device</span>
+          </label>
+          <p class="form-helper">
+            Feature access is controlled by license flags: <strong>extract</strong> for file uploads,
+            <strong>classify</strong> for text classification, and <strong>predict</strong> for payment scoring.
+          </p>
+        </form>
+      </section>
+
+      <section class="card" id="extract-panel">
+        <div class="card__header">
+          <h2>Invoice Extraction</h2>
+          <span class="feature-badge" aria-label="Requires extract feature">extract</span>
+        </div>
+        <p class="card__lead">
+          Drag-and-drop or browse for a PDF or image invoice. The service will return parsed supplier, totals, line items, and raw text.
+        </p>
+        <form id="extract-form" class="card__body" novalidate>
+          <div class="drop-zone" id="extract-drop-zone">
+            <div class="drop-zone__hint">
+              <strong>Drop invoice files here</strong>
+              <span>or</span>
+            </div>
+            <button type="button" class="button button--outline" id="extract-file-button">Choose a file</button>
+            <input type="file" id="extract-file" name="file" accept=".pdf,.png,.jpg,.jpeg" />
+            <p class="drop-zone__file" id="extract-file-name">No file selected</p>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="button button--primary" id="extract-submit">Extract invoice</button>
+            <div class="loading" id="extract-loading" hidden>Processing…</div>
+          </div>
+        </form>
+        <div class="results" id="extract-result" aria-live="polite"></div>
+      </section>
+
+      <section class="card" id="classify-panel">
+        <div class="card__header">
+          <h2>Text Classification</h2>
+          <span class="feature-badge" aria-label="Requires classify feature">classify</span>
+        </div>
+        <p class="card__lead">
+          Paste raw invoice text to predict the document type. The classifier returns the best-fit label and probability.
+        </p>
+        <form id="classify-form" class="card__body" novalidate>
+          <label class="form-field">
+            <span class="form-label">Invoice text</span>
+            <textarea id="classify-text" rows="8" placeholder="Paste or type invoice contents"></textarea>
+          </label>
+          <div class="form-actions">
+            <button type="submit" class="button button--primary" id="classify-submit">Classify text</button>
+            <div class="loading" id="classify-loading" hidden>Scoring…</div>
+          </div>
+        </form>
+        <div class="results" id="classify-result" aria-live="polite"></div>
+      </section>
+
+      <section class="card" id="predict-panel">
+        <div class="card__header">
+          <h2>Payment Prediction</h2>
+          <span class="feature-badge" aria-label="Requires predict feature">predict</span>
+        </div>
+        <p class="card__lead">
+          Provide feature key/value pairs to score expected payment timing. You can target the canonical endpoint or the <code>/predict</code> alias.
+        </p>
+        <form id="predict-form" class="card__body" novalidate>
+          <div class="feature-table-wrapper">
+            <table class="feature-table" aria-describedby="predict-panel">
+              <thead>
+                <tr>
+                  <th scope="col">Feature key</th>
+                  <th scope="col">Value</th>
+                  <th scope="col" class="feature-table__actions">Actions</th>
+                </tr>
+              </thead>
+              <tbody id="feature-rows"></tbody>
+            </table>
+            <button type="button" class="button button--ghost" id="add-feature-row">Add feature</button>
+          </div>
+
+          <div class="form-grid form-grid--compact">
+            <label class="form-field">
+              <span class="form-label">Endpoint</span>
+              <select id="predict-endpoint">
+                <option value="/invoices/predict">/invoices/predict</option>
+                <option value="/predict">/predict</option>
+              </select>
+            </label>
+            <div class="form-actions form-actions--end">
+              <button type="submit" class="button button--primary" id="predict-submit">Score payment</button>
+              <div class="loading" id="predict-loading" hidden>Evaluating…</div>
+            </div>
+          </div>
+        </form>
+        <div class="results" id="predict-result" aria-live="polite"></div>
+      </section>
+    </main>
+
+    <template id="feature-row-template">
+      <tr class="feature-row">
+        <td data-label="Feature key">
+          <input type="text" class="feature-key" placeholder="e.g. amount" />
+        </td>
+        <td data-label="Value">
+          <input type="text" class="feature-value" placeholder="e.g. 950" />
+        </td>
+        <td class="feature-table__actions" data-label="Actions">
+          <button type="button" class="button button--icon remove-feature" aria-label="Remove feature row">
+            ✕
+          </button>
+        </td>
+      </tr>
+    </template>
+
+    <script src="{{ url_for('static', path='js/invoice_portal.js') }}" type="module"></script>
+  </body>
+</html>

--- a/tests/test_invoice_portal.py
+++ b/tests/test_invoice_portal.py
@@ -1,0 +1,57 @@
+"""Integration tests for the invoice portal template and assets."""
+
+from pathlib import Path
+import os
+import sys
+
+from fastapi import Request
+from starlette.templating import _TemplateResponse
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(PROJECT_ROOT / "src"))
+
+os.environ.setdefault("API_KEY", "portal-test-secret")
+
+from api.main import app, invoice_portal  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def _build_request() -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/portal",
+        "root_path": "",
+        "app": app,
+        "headers": [],
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("testclient", 12345),
+    }
+    return Request(scope)
+
+
+def test_invoice_portal_template_served() -> None:
+    request = _build_request()
+    response = invoice_portal(request)
+
+    assert isinstance(response, _TemplateResponse)
+    assert response.template.name == "invoice_portal.html"
+    assert response.context["request"] is request
+
+    rendered = response.body.decode("utf-8")
+    assert "Invoice Operations Portal" in rendered
+    assert "/static/js/invoice_portal.js" in rendered
+
+
+def test_invoice_portal_static_asset_paths_resolve() -> None:
+    css_path = app.url_path_for("static", path="css/invoice_portal.css")
+    js_path = app.url_path_for("static", path="js/invoice_portal.js")
+
+    assert css_path == "/static/css/invoice_portal.css"
+    assert js_path == "/static/js/invoice_portal.js"
+
+    css_file = PROJECT_ROOT / "src" / "api" / "static" / "css" / "invoice_portal.css"
+    js_file = PROJECT_ROOT / "src" / "api" / "static" / "js" / "invoice_portal.js"
+
+    assert css_file.exists()
+    assert js_file.exists()


### PR DESCRIPTION
## Summary
- add a FastAPI `/portal` view that serves the new invoice operations workspace
- create HTML/CSS/JS assets that support credential storage, invoice extraction, text classification, and payment prediction flows
- document how to launch the portal and exercise feature flags, and add tests ensuring the route and static bundles resolve

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d380c35a808329b3472c89de9ccc44