### PR TITLE
Add TICA PDF workflow and responsive portal updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ This repository contains a cross-platform AI service (Python/FastAPI) and Window
    curl -H "X-API-Key: $AI_API_KEY" -H "Content-Type: application/json" -d '{"features":{"amount":950,"customer_age_days":400,"prior_invoices":12,"late_ratio":0.2,"weekday":2,"month":9}}' http://localhost:8088/predict
 ````
 
-5. (Optional) Interact with the classifier management endpoints:
+5. Open the interactive portal at [http://localhost:8088/portal](http://localhost:8088/portal) to upload invoices, classify text, score predictions, and export Costa Rica TICA-compliant customs PDFs. The responsive UI surfaces validation errors (401/403/413) directly and can optionally remember your API key/license token. See [docs/invoice_portal.md](docs/invoice_portal.md) for a guided tour of each workflow.
+
+6. (Optional) Interact with the classifier management endpoints:
 
 ````bash
    curl -H "X-API-Key: $AI_API_KEY" http://localhost:8088/models/classifier/status

--- a/docs/invoice_portal.md
+++ b/docs/invoice_portal.md
@@ -1,0 +1,72 @@
+# Invoice Operations Portal
+
+The invoice portal is a FastAPI-powered workspace that bundles the most common invoice operations into a single, client-side experience. It lives alongside the existing admin console and is ideal for manual testing, demos, and troubleshooting.
+
+## Launching the portal
+
+1. Configure and run the API service as described in the project README. In development you can launch the server with:
+
+   ```bash
+   uv run uvicorn api.main:app --reload --port 8088
+   ```
+
+2. Navigate to [http://localhost:8088/portal](http://localhost:8088/portal) in a modern browser.
+
+   The UI is entirely client-side and communicates with the FastAPI endpoints that already power automated workflows.
+
+## Authentication and licensing
+
+The portal uses the same security middleware as the REST API:
+
+- **X-API-Key** – required on every non-health request when `API_KEY` (or `AI_API_KEY`) is configured. Enter the key in the *Authentication* card. You can optionally store the value in `localStorage` by ticking **“Remember these secrets on this device”**.
+- **X-License-Token** – required when license enforcement is enabled. Paste a signed token containing the necessary feature flags. The UI never persists the token unless you opt in.
+
+If you do not enable the “remember” toggle the secrets stay in memory for the duration of the tab only. Clearing the toggle immediately wipes any stored values.
+
+### Feature flags
+
+Each invoice workflow requires a dedicated feature flag to be present in the license token:
+
+| Feature flag | Enables |
+| --- | --- |
+| `extract` | Uploading files to `/invoices/extract` and generating customs PDFs at `/invoices/tica-pdf`. |
+| `classify` | Sending text payloads to `/invoices/classify`. |
+| `predict` | Scoring feature vectors via `/invoices/predict` or `/predict`. |
+
+If the token is missing a feature you will receive an HTTP 403 with an explanatory message. HTTP 401 responses usually indicate a missing or invalid API key or license signature.
+
+## Available workflows
+
+### Invoice extraction
+
+- Drag-and-drop a PDF, PNG, or JPEG into the drop zone (or browse for a file).
+- Click **Extract invoice** to call `POST /invoices/extract`.
+- Successful responses show normalized header fields, totals, line items, and the captured raw text. Validation errors (empty file, max upload bytes) surface inline with a red banner.
+
+### Text classification
+
+- Paste unstructured invoice text into the editor and submit the form.
+- The UI issues `POST /invoices/classify` and displays the predicted label alongside the probability score.
+- Exceeding the configured length limit or submitting empty text returns a 400/413 response that is rendered in the results panel.
+
+### Payment prediction
+
+- Use the feature table to define key/value pairs for predictive scoring. Add or remove rows as needed; blank rows are ignored.
+- Select either the canonical `/invoices/predict` endpoint or the `/predict` alias.
+- The payload is POSTed as JSON (`{"features": {...}}`). The portal automatically coerces numeric and boolean literals when possible and prints the resulting prediction, risk score, and confidence.
+
+### TICA customs PDF export
+
+- Complete the metadata panels to capture invoice numbering, customs references, logistics details, and exporter/importer credentials.
+- Populate the goods table with HS codes, origin, quantities, and values. Leave the “Total value” column blank to auto-calculate `quantity × unit value` per line.
+- Submit the form to call `POST /invoices/tica-pdf`. On success the browser downloads a PDF formatted for Costa Rica’s *Tecnología de Información para el Control Aduanero* (TICA) system.
+- The workflow reuses the `extract` feature flag. Missing license permissions or validation errors render inline banners so you can correct the data without leaving the page.
+
+## Troubleshooting
+
+- **413 Payload Too Large** – Increase `MAX_UPLOAD_BYTES` (files) or `MAX_JSON_BODY_BYTES`/`MAX_TEXT_LENGTH` (JSON/text) in your configuration, or submit smaller inputs.
+- **401/403 Unauthorized** – Confirm the API key and license token match the service configuration. Token claims must include the required feature flag(s).
+- **429 Too Many Requests** – The middleware enforces rate limiting when configured. Reduce request frequency or adjust `RATE_LIMIT_PER_MINUTE`/`RATE_LIMIT_BURST`.
+- **Unexpected errors** – Network failures and JSON parsing issues are surfaced inline. Use browser developer tools for deeper inspection and review server logs for stack traces.
+
+The portal enhances (but does not replace) automated integration tests. Its layout adapts to tablets and phones, so you can triage invoices from the field while keeping secrets scoped to the current browser (unless you explicitly opt in to persistence). It is designed to be safe to host in trusted environments where direct API access is appropriate.

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -31,7 +31,7 @@ if not settings.api_key and not getattr(settings, "allow_anonymous", False):
 
 from .license_validator import LicenseClaims, ensure_feature, require_feature_flag
 from .middleware import configure_middleware
-from .routers import admin, health, invoices, models, predictive
+from .routers import admin, health, invoices, models, predictive, tica
 from .routers.invoices import PredictRequest, predict_from_features
 
 
@@ -55,6 +55,7 @@ app.include_router(invoices.router)
 app.include_router(models.router)
 app.include_router(predictive.router)
 app.include_router(admin.router)
+app.include_router(tica.router)
 
 
 @app.get("/")
@@ -64,7 +65,14 @@ def root() -> dict[str, str]:
 
 @app.get("/admin", response_class=HTMLResponse)
 def admin_portal(request: Request) -> HTMLResponse:
-    return _TEMPLATES.TemplateResponse("admin.html", {"request": request})
+    return _TEMPLATES.TemplateResponse(request, "admin.html", {"request": request})
+
+
+@app.get("/portal", response_class=HTMLResponse)
+def invoice_portal(request: Request) -> HTMLResponse:
+    """Render the interactive workspace for invoice operations."""
+
+    return _TEMPLATES.TemplateResponse(request, "invoice_portal.html", {"request": request})
 
 
 @app.post("/predict", response_model=PredictiveResult, tags=["invoices"])

--- a/src/api/routers/tica.py
+++ b/src/api/routers/tica.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from io import BytesIO
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, ConfigDict, Field, conlist
+
+from ..license_validator import LicenseClaims, ensure_feature, require_feature_flag
+
+
+router = APIRouter(prefix="/invoices", tags=["invoices"])
+require_extract_feature = require_feature_flag("extract")
+
+
+def _to_decimal(value: Decimal | float | int | str | None) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if value is None:
+        return Decimal("0")
+    return Decimal(str(value))
+
+
+def _format_currency(value: Decimal | float | int, currency: str) -> str:
+    amount = _to_decimal(value).quantize(Decimal("0.01"))
+    return f"{currency} {amount:,.2f}"
+
+
+def _format_quantity(value: Decimal | float | int) -> str:
+    quantity = _to_decimal(value).normalize()
+    # fpdf/locale independent formatting: strip exponent when integer
+    if quantity == quantity.to_integral():
+        return f"{quantity:.0f}"
+    return f"{quantity:.3f}".rstrip("0").rstrip(".")
+
+
+class TicaInvoiceItem(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True, populate_by_name=True)
+
+    description: str = Field(..., max_length=200)
+    quantity: Decimal = Field(..., gt=0)
+    unit_value: Decimal = Field(..., ge=0)
+    total_value: Decimal | None = Field(None, ge=0)
+    hs_code: str | None = Field(None, max_length=20, alias="hs_code")
+    country_of_origin: str | None = Field(None, max_length=60, alias="country_of_origin")
+
+    def resolved_total(self) -> Decimal:
+        if self.total_value is not None:
+            return _to_decimal(self.total_value)
+        return _to_decimal(self.quantity) * _to_decimal(self.unit_value)
+
+
+class TicaInvoicePayload(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True, populate_by_name=True)
+
+    invoice_number: str = Field(..., max_length=64)
+    issue_date: date
+    exporter_name: str = Field(..., max_length=120)
+    exporter_id: str = Field(..., max_length=50)
+    exporter_address: str | None = Field(None, max_length=200)
+    importer_name: str = Field(..., max_length=120)
+    importer_id: str = Field(..., max_length=50)
+    importer_address: str | None = Field(None, max_length=200)
+    incoterm: str | None = Field(None, max_length=16)
+    transport_mode: str | None = Field(None, max_length=60)
+    destination_port: str | None = Field(None, max_length=80)
+    customs_reference: str | None = Field(None, max_length=80)
+    regime: str | None = Field(None, max_length=80)
+    currency: str = Field(..., max_length=12)
+    subtotal: Decimal = Field(..., ge=0)
+    tax: Decimal = Field(..., ge=0)
+    total: Decimal = Field(..., ge=0)
+    notes: str | None = Field(None, max_length=800)
+    items: conlist(TicaInvoiceItem, min_length=1)
+
+
+class SimplePdfBuilder:
+    """Minimal PDF builder that writes positioned Helvetica text."""
+
+    PAGE_WIDTH = 595
+    PAGE_HEIGHT = 842
+    MARGIN_X = 56
+    MARGIN_TOP = 780
+    MARGIN_BOTTOM = 72
+    LINE_HEIGHT = 16
+    WRAP_LIMIT = 90
+
+    def __init__(self) -> None:
+        self.pages: list[list[tuple[str, int, int, int, str]]] = [[]]
+        self.current_y = self.MARGIN_TOP
+
+    def _wrap(self, text: str | None) -> list[str]:
+        if text is None:
+            return ["N/A"]
+        stripped = str(text).strip()
+        if not stripped:
+            return ["N/A"]
+        words = stripped.split()
+        lines: list[str] = []
+        current = ""
+        for word in words:
+            candidate = f"{current} {word}".strip()
+            if len(candidate) <= self.WRAP_LIMIT:
+                current = candidate
+            else:
+                if current:
+                    lines.append(current)
+                current = word
+        if current:
+            lines.append(current)
+        return lines or [stripped]
+
+    def _ensure_space(self, required: int) -> None:
+        if self.current_y - required < self.MARGIN_BOTTOM:
+            self.pages.append([])
+            self.current_y = self.MARGIN_TOP
+
+    def add_line(self, text: str | None, *, font: str = "F1", size: int = 11, indent: int = 0) -> None:
+        lines = self._wrap(text)
+        for line in lines:
+            self._ensure_space(self.LINE_HEIGHT)
+            x = self.MARGIN_X + indent
+            self.pages[-1].append((font, size, x, self.current_y, line))
+            self.current_y -= self.LINE_HEIGHT
+
+    def add_spacing(self, amount: int) -> None:
+        self.current_y -= amount
+
+    def add_title(self, text: str) -> None:
+        self._ensure_space(32)
+        self.pages[-1].append(("F2", 18, self.MARGIN_X, self.current_y, text))
+        self.current_y -= 26
+
+    def add_section_heading(self, text: str) -> None:
+        self.add_spacing(4)
+        self._ensure_space(20)
+        heading = text.strip().upper()
+        self.pages[-1].append(("F2", 12, self.MARGIN_X, self.current_y, heading))
+        self.current_y -= 18
+
+    def add_field(self, label: str, value: str | None) -> None:
+        self.add_line(f"{label}: {value or 'N/A'}")
+
+    def add_paragraph(self, text: str) -> None:
+        for part in str(text).splitlines() or [""]:
+            self.add_line(part, size=10)
+
+    def add_bullet(self, text: str) -> None:
+        self.add_line(f"- {text}", size=10, indent=12)
+
+    @staticmethod
+    def _escape(text: str) -> str:
+        return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+    def render(self) -> bytes:
+        pages = [page for page in self.pages if page]
+        if not pages:
+            pages = [[("F1", 11, self.MARGIN_X, self.MARGIN_TOP, "")]]
+
+        object_contents: list[bytes] = []
+        # Font definitions
+        object_contents.append(b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+        object_contents.append(b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>")
+
+        for page in pages:
+            commands = []
+            for font, size, x, y, text in page:
+                escaped = self._escape(text)
+                commands.append(
+                    f"BT\n/{font} {size} Tf\n1 0 0 1 {x} {y} Tm\n({escaped}) Tj\nET\n"
+                )
+            stream = "".join(commands).encode("latin-1", errors="replace")
+            object_contents.append(
+                b"<< /Length "
+                + str(len(stream)).encode("ascii")
+                + b" >>\nstream\n"
+                + stream
+                + b"\nendstream"
+            )
+
+        num_pages = len(pages)
+        page_start = len(object_contents) + 1
+        pages_index = page_start + num_pages
+        catalog_index = pages_index + 1
+
+        for idx in range(num_pages):
+            content_index = 3 + idx
+            page_obj = (
+                f"<< /Type /Page /Parent {pages_index} 0 R /MediaBox [0 0 {self.PAGE_WIDTH} {self.PAGE_HEIGHT}] "
+                f"/Contents {content_index} 0 R /Resources << /Font << /F1 1 0 R /F2 2 0 R >> >> >>"
+            ).encode("ascii")
+            object_contents.append(page_obj)
+
+        kids = " ".join(f"{page_start + i} 0 R" for i in range(num_pages))
+        pages_obj = f"<< /Type /Pages /Kids [{kids}] /Count {num_pages} >>".encode("ascii")
+        object_contents.append(pages_obj)
+
+        catalog_obj = f"<< /Type /Catalog /Pages {pages_index} 0 R >>".encode("ascii")
+        object_contents.append(catalog_obj)
+
+        buffer = BytesIO()
+        buffer.write(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+        offsets = [0]
+
+        for index, content in enumerate(object_contents, start=1):
+            offsets.append(buffer.tell())
+            buffer.write(f"{index} 0 obj\n".encode("ascii"))
+            buffer.write(content)
+            buffer.write(b"\nendobj\n")
+
+        xref_offset = buffer.tell()
+        buffer.write(f"xref\n0 {len(offsets)}\n".encode("ascii"))
+        buffer.write(b"0000000000 65535 f \n")
+        for offset in offsets[1:]:
+            buffer.write(f"{offset:010d} 00000 n \n".encode("ascii"))
+
+        buffer.write(
+            f"trailer\n<< /Size {len(offsets)} /Root {catalog_index} 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n".encode("ascii")
+        )
+        return buffer.getvalue()
+
+
+def _build_tica_pdf(payload: TicaInvoicePayload) -> bytes:
+    builder = SimplePdfBuilder()
+    builder.add_title("Factura Comercial - Formato TICA")
+
+    builder.add_section_heading("Datos de la factura")
+    builder.add_field("Número de factura", payload.invoice_number)
+    builder.add_field("Fecha de emisión", payload.issue_date.strftime("%d/%m/%Y"))
+    builder.add_field("Referencia aduanera", payload.customs_reference)
+    builder.add_field("Régimen", payload.regime)
+    builder.add_field("Incoterm", payload.incoterm)
+
+    builder.add_section_heading("Exportador")
+    builder.add_field("Nombre", payload.exporter_name)
+    builder.add_field("Identificación", payload.exporter_id)
+    builder.add_field("Dirección", payload.exporter_address)
+
+    builder.add_section_heading("Importador")
+    builder.add_field("Nombre", payload.importer_name)
+    builder.add_field("Identificación", payload.importer_id)
+    builder.add_field("Dirección", payload.importer_address)
+
+    builder.add_section_heading("Logística")
+    builder.add_field("Medio de transporte", payload.transport_mode)
+    builder.add_field("Puerto / Aduana de ingreso", payload.destination_port)
+
+    builder.add_section_heading("Mercancías")
+    for item in payload.items:
+        parts = [
+            item.description,
+            f"Cant.: {_format_quantity(item.quantity)}",
+            f"Unit.: {_format_currency(item.unit_value, payload.currency)}",
+            f"Total: {_format_currency(item.resolved_total(), payload.currency)}",
+        ]
+        classification = " / ".join(filter(None, [item.hs_code, item.country_of_origin]))
+        if classification:
+            parts.append(f"Clasificación: {classification}")
+        builder.add_bullet(" | ".join(parts))
+
+    if not payload.items:
+        builder.add_bullet("No se reportaron mercancías.")
+
+    builder.add_section_heading("Totales")
+    builder.add_field("Subtotal", _format_currency(payload.subtotal, payload.currency))
+    builder.add_field("Impuestos", _format_currency(payload.tax, payload.currency))
+    builder.add_field("Total factura", _format_currency(payload.total, payload.currency))
+
+    if payload.notes:
+        builder.add_section_heading("Notas")
+        builder.add_paragraph(payload.notes)
+
+    return builder.render()
+
+
+@router.post("/tica-pdf", response_class=StreamingResponse)
+def generate_tica_invoice_pdf(
+    payload: TicaInvoicePayload,
+    claims: LicenseClaims = Depends(require_extract_feature),
+) -> StreamingResponse:
+    """Generate a PDF tailored to the TICA customs platform requirements."""
+
+    ensure_feature(claims, "extract")
+
+    pdf_bytes = _build_tica_pdf(payload)
+    buffer = BytesIO(pdf_bytes)
+    filename = f"tica_invoice_{payload.invoice_number}.pdf"
+
+    return StreamingResponse(
+        buffer,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f"attachment; filename=\"{filename}\""},
+    )
+

--- a/src/api/static/css/invoice_portal.css
+++ b/src/api/static/css/invoice_portal.css
@@ -1,0 +1,658 @@
+:root {
+  color-scheme: light;
+  --color-background: #f5f7fb;
+  --color-surface: #ffffff;
+  --color-border: #d7deea;
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-primary-soft: rgba(37, 99, 235, 0.1);
+  --color-text: #1f2937;
+  --color-muted: #6b7280;
+  --color-success: #0f766e;
+  --color-danger: #dc2626;
+  --shadow-soft: 0 12px 30px rgba(15, 23, 42, 0.08);
+  --radius-large: 18px;
+  --radius-medium: 12px;
+  --radius-small: 8px;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f9fbff 0%, #eef2f9 100%);
+  color: var(--color-text);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.page-header {
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.12), transparent 55%),
+    linear-gradient(135deg, #0f172a, #1d4ed8);
+  color: #f8fafc;
+  padding: 56px 24px 48px;
+  text-align: center;
+  box-shadow: var(--shadow-soft);
+  border-bottom-left-radius: var(--radius-large);
+  border-bottom-right-radius: var(--radius-large);
+}
+
+.page-header__content {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.page-header__subtitle {
+  margin: 12px auto 24px;
+  max-width: 680px;
+  font-size: 1.05rem;
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.page-header__links {
+  display: flex;
+  justify-content: center;
+  gap: 18px;
+}
+
+.page-header__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background-color: rgba(15, 23, 42, 0.35);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  transition: background-color 150ms ease, transform 150ms ease;
+}
+
+.page-header__link:hover,
+.page-header__link:focus {
+  background-color: rgba(37, 99, 235, 0.5);
+  transform: translateY(-1px);
+}
+
+.portal {
+  max-width: 1100px;
+  margin: -48px auto 64px;
+  padding: 0 24px 64px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 360px), 1fr));
+  gap: 32px;
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: var(--radius-large);
+  padding: 28px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.card--wide {
+  grid-column: 1 / -1;
+}
+
+.card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.card__lead {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.form-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.form-grid--responsive {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: end;
+  gap: 16px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-field--wide {
+  grid-column: 1 / -1;
+}
+
+.form-label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.form-field input,
+.form-field textarea,
+.form-field select {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-small);
+  padding: 10px 14px;
+  font-size: 0.95rem;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+  background: #fff;
+}
+
+.form-field textarea {
+  resize: vertical;
+}
+
+.form-field input:focus,
+.form-field textarea:focus,
+.form-field select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-soft);
+}
+
+.form-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.form-checkbox input {
+  width: 18px;
+  height: 18px;
+}
+
+.form-helper {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.form-actions--end {
+  justify-content: flex-end;
+}
+
+.button {
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, background-color 120ms ease;
+  border: 1px solid transparent;
+}
+
+.button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.button--primary {
+  background: var(--color-primary);
+  color: #fff;
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.25);
+}
+
+.button--primary:hover,
+.button--primary:focus {
+  background: var(--color-primary-hover);
+  transform: translateY(-1px);
+}
+
+.button--outline {
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid var(--color-border);
+  color: var(--color-primary);
+}
+
+.button--outline:hover,
+.button--outline:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-soft);
+}
+
+.button--ghost {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-primary);
+  border: 1px dashed rgba(37, 99, 235, 0.3);
+}
+
+.button--ghost:hover,
+.button--ghost:focus {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.button--icon {
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.05);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.button--icon:hover,
+.button--icon:focus {
+  background: rgba(220, 38, 38, 0.1);
+  color: var(--color-danger);
+  border-color: rgba(220, 38, 38, 0.25);
+}
+
+textarea {
+  resize: vertical;
+  min-height: 160px;
+}
+
+.drop-zone {
+  position: relative;
+  border: 2px dashed rgba(37, 99, 235, 0.35);
+  border-radius: var(--radius-medium);
+  padding: 28px 18px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  background: rgba(37, 99, 235, 0.06);
+  transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
+}
+
+.drop-zone.is-dragover {
+  border-color: var(--color-primary);
+  background: rgba(37, 99, 235, 0.14);
+  transform: translateY(-2px);
+}
+
+.drop-zone__hint strong {
+  display: block;
+  font-size: 1rem;
+  margin-bottom: 4px;
+}
+
+.drop-zone input[type='file'] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.drop-zone__file {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.feature-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-primary);
+  background: rgba(37, 99, 235, 0.12);
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+.feature-table-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.table-scroll {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: var(--radius-medium);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.03);
+}
+
+.feature-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  border-radius: var(--radius-medium);
+  overflow: hidden;
+  background: #fff;
+}
+
+.feature-table th,
+.feature-table td {
+  padding: 12px 14px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.05);
+  text-align: left;
+  background: #fff;
+}
+
+.feature-table tbody tr:last-of-type td {
+  border-bottom: none;
+}
+
+.feature-row.has-error input {
+  border-color: var(--color-danger);
+  box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.2);
+}
+
+.tica-row.has-error input,
+.tica-row.has-error textarea {
+  border-color: var(--color-danger);
+  box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.2);
+}
+
+.feature-table--tight th,
+.feature-table--tight td {
+  padding: 10px 12px;
+}
+
+.tica-row textarea {
+  min-height: 52px;
+}
+
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form-section__title {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.loading {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.loading::before {
+  content: '';
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.6);
+  border-top-color: var(--color-primary);
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.results {
+  background: rgba(15, 23, 42, 0.03);
+  border-radius: var(--radius-medium);
+  padding: 20px;
+  min-height: 60px;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.results:empty {
+  display: none;
+}
+
+.results.has-error {
+  border-color: rgba(220, 38, 38, 0.25);
+  background: rgba(254, 226, 226, 0.55);
+}
+
+.results details {
+  margin-top: 12px;
+}
+
+.results details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.results pre {
+  margin: 12px 0 0;
+  background: #fff;
+  border-radius: var(--radius-small);
+  padding: 12px;
+  max-height: 260px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.result-card h3,
+.result-card h4 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.result-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px 24px;
+}
+
+.result-grid dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.result-grid dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.result-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-small);
+  overflow: hidden;
+}
+
+.result-table th,
+.result-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.05);
+  text-align: left;
+}
+
+.result-table tbody tr:nth-child(odd) {
+  background: rgba(15, 23, 42, 0.03);
+}
+
+.result-meta {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  margin-top: 12px;
+}
+
+.error-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--color-danger);
+  font-weight: 600;
+}
+
+.error-banner__detail {
+  font-weight: 400;
+}
+
+code {
+  font-family: 'Fira Code', 'SFMono-Regular', Menlo, Consolas, monospace;
+  background: rgba(15, 23, 42, 0.08);
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+.muted {
+  color: var(--color-muted);
+}
+
+@media (max-width: 768px) {
+  .portal {
+    margin-top: -32px;
+    grid-template-columns: 1fr;
+  }
+
+  .card {
+    padding: 22px;
+  }
+
+  .page-header {
+    padding: 40px 20px 36px;
+  }
+
+  .page-header__links {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .form-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .form-actions--end {
+    align-items: stretch;
+  }
+
+  .button--primary,
+  .button--outline {
+    width: 100%;
+  }
+
+  .feature-table__actions {
+    text-align: right;
+  }
+}
+
+@media (max-width: 640px) {
+  .portal {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .page-header h1 {
+    font-size: 1.75rem;
+  }
+
+  .feature-table thead {
+    display: none;
+  }
+
+  .feature-table tbody {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .feature-table tbody tr {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: var(--radius-small);
+    padding: 12px 16px;
+    gap: 10px;
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.02);
+  }
+
+  .feature-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    border: none;
+    padding: 4px 0;
+    background: transparent;
+  }
+
+  .feature-table td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    color: var(--color-muted);
+    margin-right: 16px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.75rem;
+  }
+
+  .feature-table__actions {
+    justify-content: flex-end;
+  }
+
+  .table-scroll {
+    box-shadow: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/api/static/js/invoice_portal.js
+++ b/src/api/static/js/invoice_portal.js
@@ -1,0 +1,999 @@
+class ApiError extends Error {
+  constructor(status, message, payload) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.payload = payload;
+  }
+}
+
+const STORAGE_KEY = 'ai-invoice-portal.credentials';
+
+const elements = {
+  apiKey: document.getElementById('api-key'),
+  licenseToken: document.getElementById('license-token'),
+  rememberSecrets: document.getElementById('remember-secrets'),
+  extract: {
+    form: document.getElementById('extract-form'),
+    fileInput: document.getElementById('extract-file'),
+    fileName: document.getElementById('extract-file-name'),
+    trigger: document.getElementById('extract-file-button'),
+    dropZone: document.getElementById('extract-drop-zone'),
+    submit: document.getElementById('extract-submit'),
+    loading: document.getElementById('extract-loading'),
+    result: document.getElementById('extract-result'),
+  },
+  classify: {
+    form: document.getElementById('classify-form'),
+    text: document.getElementById('classify-text'),
+    submit: document.getElementById('classify-submit'),
+    loading: document.getElementById('classify-loading'),
+    result: document.getElementById('classify-result'),
+  },
+  predict: {
+    form: document.getElementById('predict-form'),
+    tableBody: document.getElementById('feature-rows'),
+    template: document.getElementById('feature-row-template'),
+    addRow: document.getElementById('add-feature-row'),
+    endpoint: document.getElementById('predict-endpoint'),
+    submit: document.getElementById('predict-submit'),
+    loading: document.getElementById('predict-loading'),
+    result: document.getElementById('predict-result'),
+  },
+  tica: {
+    form: document.getElementById('tica-form'),
+    tableBody: document.getElementById('tica-rows'),
+    template: document.getElementById('tica-row-template'),
+    addItem: document.getElementById('add-tica-item'),
+    submit: document.getElementById('tica-submit'),
+    loading: document.getElementById('tica-loading'),
+    result: document.getElementById('tica-result'),
+  },
+};
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function muted(text = '—') {
+  return `<span class="muted">${escapeHtml(text)}</span>`;
+}
+
+function normaliseErrorDetail(detail) {
+  if (detail == null) {
+    return 'Unexpected error.';
+  }
+  if (typeof detail === 'string') {
+    return detail;
+  }
+  if (Array.isArray(detail)) {
+    return detail
+      .map((item) => normaliseErrorDetail(item))
+      .filter(Boolean)
+      .join('\n');
+  }
+  if (typeof detail === 'object') {
+    if (Object.prototype.hasOwnProperty.call(detail, 'detail')) {
+      return normaliseErrorDetail(detail.detail);
+    }
+    if (Object.prototype.hasOwnProperty.call(detail, 'message')) {
+      return normaliseErrorDetail(detail.message);
+    }
+    if (Object.prototype.hasOwnProperty.call(detail, 'msg')) {
+      const prefix = Array.isArray(detail.loc) ? `${detail.loc.join('.')}: ` : '';
+      return `${prefix}${detail.msg}`;
+    }
+    try {
+      return JSON.stringify(detail, null, 2);
+    } catch (error) {
+      return String(detail);
+    }
+  }
+  return String(detail);
+}
+
+async function sendRequest(
+  url,
+  { method = 'GET', headers = new Headers(), body = undefined, responseType = 'auto' } = {},
+) {
+  const response = await fetch(url, { method, headers, body });
+
+  if (!response.ok) {
+    let parsed;
+    let detail;
+    try {
+      const text = await response.text();
+      if (text) {
+        try {
+          parsed = JSON.parse(text);
+        } catch (parseError) {
+          parsed = text;
+        }
+      } else {
+        parsed = '';
+      }
+    } catch (readError) {
+      parsed = '';
+    }
+    detail = normaliseErrorDetail(parsed);
+    throw new ApiError(response.status, detail, parsed);
+  }
+
+  if (responseType === 'binary') {
+    return await response.blob();
+  }
+
+  if (responseType === 'text') {
+    try {
+      return await response.text();
+    } catch (error) {
+      return '';
+    }
+  }
+
+  const contentType = response.headers.get('Content-Type') || '';
+  if (contentType.includes('application/json')) {
+    try {
+      return await response.json();
+    } catch (error) {
+      return {};
+    }
+  }
+
+  try {
+    return await response.text();
+  } catch (error) {
+    return '';
+  }
+}
+
+function readCredentials() {
+  return {
+    apiKey: elements.apiKey?.value.trim() ?? '',
+    licenseToken: elements.licenseToken?.value.trim() ?? '',
+  };
+}
+
+function buildHeaders(additional = {}) {
+  const headers = new Headers();
+  Object.entries(additional).forEach(([key, value]) => {
+    if (value != null) {
+      headers.set(key, value);
+    }
+  });
+  const { apiKey, licenseToken } = readCredentials();
+  if (apiKey) {
+    headers.set('X-API-Key', apiKey);
+  }
+  if (licenseToken) {
+    headers.set('X-License-Token', licenseToken);
+  }
+  return headers;
+}
+
+function safeStorage(action, key, value) {
+  try {
+    if (!window.localStorage) {
+      return null;
+    }
+  } catch (error) {
+    return null;
+  }
+
+  try {
+    if (action === 'get') {
+      return window.localStorage.getItem(key);
+    }
+    if (action === 'set') {
+      window.localStorage.setItem(key, value ?? '');
+    }
+    if (action === 'remove') {
+      window.localStorage.removeItem(key);
+    }
+  } catch (error) {
+    console.warn('Unable to access localStorage', error);
+  }
+  return null;
+}
+
+function persistCredentialsIfNeeded() {
+  if (!elements.rememberSecrets) {
+    return;
+  }
+  if (!elements.rememberSecrets.checked) {
+    safeStorage('remove', STORAGE_KEY);
+    return;
+  }
+  const credentials = readCredentials();
+  const serialised = JSON.stringify(credentials);
+  safeStorage('set', STORAGE_KEY, serialised);
+}
+
+function restoreCredentials() {
+  const stored = safeStorage('get', STORAGE_KEY);
+  if (!stored) {
+    return;
+  }
+  try {
+    const credentials = JSON.parse(stored);
+    if (credentials.apiKey && elements.apiKey) {
+      elements.apiKey.value = credentials.apiKey;
+    }
+    if (credentials.licenseToken && elements.licenseToken) {
+      elements.licenseToken.value = credentials.licenseToken;
+    }
+    if (elements.rememberSecrets) {
+      elements.rememberSecrets.checked = true;
+    }
+  } catch (error) {
+    console.warn('Stored credentials could not be parsed', error);
+  }
+}
+
+function setLoading(button, indicator, busy) {
+  if (!button || !indicator) {
+    return;
+  }
+  button.disabled = busy;
+  indicator.hidden = !busy;
+  button.setAttribute('aria-busy', String(busy));
+}
+
+function clearResult(container) {
+  if (!container) {
+    return;
+  }
+  container.innerHTML = '';
+  container.classList.remove('has-error');
+}
+
+function setResult(container, html, isError = false) {
+  if (!container) {
+    return;
+  }
+  container.innerHTML = html;
+  container.classList.toggle('has-error', isError);
+}
+
+function renderError(container, message, status) {
+  const statusLabel = status ? `Request failed (HTTP ${status})` : 'Request failed';
+  const detail = escapeHtml(message);
+  setResult(
+    container,
+    `<div class="error-banner"><span>${statusLabel}</span><span class="error-banner__detail">${detail}</span></div>`,
+    true,
+  );
+}
+
+function formatValue(value) {
+  if (value === null || value === undefined || value === '') {
+    return muted();
+  }
+  if (typeof value === 'number') {
+    return escapeHtml(value.toLocaleString(undefined, { maximumFractionDigits: 4 }));
+  }
+  return escapeHtml(String(value));
+}
+
+function formatNumber(value, decimals = 2) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) {
+    return muted();
+  }
+  const number = Number(value);
+  return escapeHtml(
+    number.toLocaleString(undefined, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    }),
+  );
+}
+
+function formatProbability(value) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) {
+    return muted();
+  }
+  const number = Number(value);
+  const percent = number * 100;
+  return escapeHtml(
+    percent.toLocaleString(undefined, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 2,
+    }) + '%',
+  );
+}
+
+function normaliseString(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function parseDecimalInput(value) {
+  const trimmed = normaliseString(value);
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = Number(trimmed);
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+  return parsed;
+}
+
+function renderExtraction(result) {
+  const container = elements.extract.result;
+  const fields = [
+    ['Supplier name', result.supplier_name],
+    ['Supplier tax ID', result.supplier_tax_id],
+    ['Invoice number', result.invoice_number],
+    ['Invoice date', result.invoice_date],
+    ['Due date', result.due_date],
+    ['Buyer name', result.buyer_name],
+    ['Buyer tax ID', result.buyer_tax_id],
+    ['Currency', result.currency],
+    ['Subtotal', result.subtotal],
+    ['Tax', result.tax],
+    ['Total', result.total],
+  ];
+
+  let html = '<div class="result-card">';
+  html += '<h3>Extracted fields</h3>';
+  html += '<dl class="result-grid">';
+  fields.forEach(([label, value]) => {
+    html += `<dt>${escapeHtml(label)}</dt><dd>${formatValue(value)}</dd>`;
+  });
+  html += '</dl>';
+
+  if (Array.isArray(result.items) && result.items.length > 0) {
+    html += '<h4>Line items</h4>';
+    html += '<table class="result-table"><thead><tr><th>Description</th><th>Qty</th><th>Unit price</th><th>Total</th></tr></thead><tbody>';
+    result.items.forEach((item) => {
+      html += '<tr>';
+      html += `<td>${formatValue(item.description)}</td>`;
+      html += `<td>${formatValue(item.quantity)}</td>`;
+      html += `<td>${formatValue(item.unit_price)}</td>`;
+      html += `<td>${formatValue(item.total)}</td>`;
+      html += '</tr>';
+    });
+    html += '</tbody></table>';
+  }
+
+  if (result.raw_text) {
+    html += `<details class="result-meta" open><summary>Raw text</summary><pre>${escapeHtml(result.raw_text)}</pre></details>`;
+  }
+
+  html += '</div>';
+  setResult(container, html);
+}
+
+function renderClassification(result) {
+  const container = elements.classify.result;
+  const html = `
+    <div class="result-card">
+      <h3>Classification result</h3>
+      <dl class="result-grid">
+        <dt>Label</dt><dd>${formatValue(result.label)}</dd>
+        <dt>Probability</dt><dd>${formatProbability(result.proba)}</dd>
+      </dl>
+    </div>
+  `;
+  setResult(container, html);
+}
+
+function renderPrediction(result) {
+  const container = elements.predict.result;
+  const html = `
+    <div class="result-card">
+      <h3>Predicted payment</h3>
+      <dl class="result-grid">
+        <dt>Expected days to pay</dt><dd>${formatNumber(result.predicted_payment_days, 1)}</dd>
+        <dt>Projected payment date</dt><dd>${formatValue(result.predicted_payment_date)}</dd>
+        <dt>Risk score</dt><dd>${formatNumber(result.risk_score, 3)}</dd>
+        <dt>Confidence</dt><dd>${formatProbability(result.confidence)}</dd>
+      </dl>
+    </div>
+  `;
+  setResult(container, html);
+}
+
+function parseFeatureValue(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.toLowerCase() === 'true') {
+    return true;
+  }
+  if (trimmed.toLowerCase() === 'false') {
+    return false;
+  }
+  const numeric = Number(trimmed);
+  if (!Number.isNaN(numeric)) {
+    return numeric;
+  }
+  return value;
+}
+
+function collectFeatures() {
+  const rows = Array.from(elements.predict.tableBody?.querySelectorAll('.feature-row') ?? []);
+  const features = {};
+  let hasError = false;
+
+  rows.forEach((row) => {
+    row.classList.remove('has-error');
+    const keyInput = row.querySelector('.feature-key');
+    const valueInput = row.querySelector('.feature-value');
+    const key = keyInput?.value.trim() ?? '';
+    const value = valueInput?.value ?? '';
+
+    if (!key && !value) {
+      return; // skip empty rows
+    }
+    if (!key) {
+      row.classList.add('has-error');
+      hasError = true;
+      return;
+    }
+    features[key] = parseFeatureValue(value);
+  });
+
+  return { features, hasError };
+}
+
+function ensureMinimumRows() {
+  const rows = elements.predict.tableBody?.querySelectorAll('.feature-row');
+  if (!rows || rows.length > 0) {
+    return;
+  }
+  addFeatureRow();
+}
+
+function addFeatureRow(key = '', value = '') {
+  const template = elements.predict.template;
+  const tbody = elements.predict.tableBody;
+  if (!template || !tbody) {
+    return;
+  }
+  const prototypeRow = template.content.firstElementChild;
+  if (!prototypeRow) {
+    return;
+  }
+  const fragment = prototypeRow.cloneNode(true);
+  const keyInput = fragment.querySelector('.feature-key');
+  const valueInput = fragment.querySelector('.feature-value');
+  const removeButton = fragment.querySelector('.remove-feature');
+
+  if (keyInput) {
+    keyInput.value = key;
+  }
+  if (valueInput) {
+    valueInput.value = value;
+  }
+  if (removeButton) {
+    removeButton.addEventListener('click', () => {
+      fragment.remove();
+      ensureMinimumRows();
+    });
+  }
+
+  tbody.appendChild(fragment);
+}
+
+function triggerDownload(blob, filename) {
+  if (!(blob instanceof Blob)) {
+    return;
+  }
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function collectTicaItems() {
+  const rows = Array.from(elements.tica.tableBody?.querySelectorAll('.tica-row') ?? []);
+  const items = [];
+  let hasError = false;
+
+  rows.forEach((row) => {
+    row.classList.remove('has-error');
+    const descriptionField = row.querySelector('.tica-description');
+    const hsField = row.querySelector('.tica-hs');
+    const originField = row.querySelector('.tica-origin');
+    const quantityField = row.querySelector('.tica-quantity');
+    const unitField = row.querySelector('.tica-unit-value');
+    const totalField = row.querySelector('.tica-total-value');
+
+    const description = normaliseString(descriptionField?.value);
+    const hs = normaliseString(hsField?.value);
+    const origin = normaliseString(originField?.value);
+    const quantityRaw = quantityField?.value;
+    const unitRaw = unitField?.value;
+    const totalRaw = totalField?.value;
+
+    const isEmpty =
+      !description &&
+      !normaliseString(quantityRaw) &&
+      !normaliseString(unitRaw) &&
+      !normaliseString(totalRaw) &&
+      !hs &&
+      !origin;
+
+    if (isEmpty) {
+      return;
+    }
+
+    const quantity = parseDecimalInput(quantityRaw);
+    const unitValue = parseDecimalInput(unitRaw);
+    const totalValue = parseDecimalInput(totalRaw);
+
+    if (!description || quantity === null || unitValue === null) {
+      row.classList.add('has-error');
+      hasError = true;
+      return;
+    }
+
+    const item = {
+      description,
+      quantity,
+      unit_value: unitValue,
+    };
+
+    if (totalValue !== null) {
+      item.total_value = totalValue;
+    }
+    if (hs) {
+      item.hs_code = hs;
+    }
+    if (origin) {
+      item.country_of_origin = origin;
+    }
+
+    items.push(item);
+  });
+
+  return { items, hasError };
+}
+
+function ensureTicaRows() {
+  const rows = elements.tica.tableBody?.querySelectorAll('.tica-row');
+  if (!rows || rows.length > 0) {
+    return;
+  }
+  addTicaRow();
+}
+
+function addTicaRow(data = {}) {
+  const template = elements.tica.template;
+  const tbody = elements.tica.tableBody;
+  if (!template || !tbody) {
+    return;
+  }
+
+  const prototypeRow = template.content.firstElementChild;
+  if (!prototypeRow) {
+    return;
+  }
+
+  const row = prototypeRow.cloneNode(true);
+  const description = row.querySelector('.tica-description');
+  const hs = row.querySelector('.tica-hs');
+  const origin = row.querySelector('.tica-origin');
+  const quantity = row.querySelector('.tica-quantity');
+  const unitValue = row.querySelector('.tica-unit-value');
+  const totalValue = row.querySelector('.tica-total-value');
+  const removeButton = row.querySelector('.remove-tica-item');
+
+  if (description) {
+    description.value = data.description ?? '';
+  }
+  if (hs) {
+    hs.value = data.hs_code ?? '';
+  }
+  if (origin) {
+    origin.value = data.country_of_origin ?? '';
+  }
+  if (quantity) {
+    quantity.value = data.quantity ?? '';
+  }
+  if (unitValue) {
+    unitValue.value = data.unit_value ?? '';
+  }
+  if (totalValue) {
+    totalValue.value = data.total_value ?? '';
+  }
+
+  if (removeButton) {
+    removeButton.addEventListener('click', () => {
+      row.remove();
+      ensureTicaRows();
+    });
+  }
+
+  tbody.appendChild(row);
+}
+
+function updateFileNameLabel() {
+  const { fileInput, fileName } = elements.extract;
+  if (!fileInput || !fileName) {
+    return;
+  }
+  const file = fileInput.files && fileInput.files[0];
+  fileName.textContent = file ? file.name : 'No file selected';
+}
+
+function setupDropZone() {
+  const { dropZone, fileInput } = elements.extract;
+  if (!dropZone || !fileInput) {
+    return;
+  }
+  dropZone.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    dropZone.classList.add('is-dragover');
+  });
+  dropZone.addEventListener('dragleave', () => {
+    dropZone.classList.remove('is-dragover');
+  });
+  dropZone.addEventListener('drop', (event) => {
+    event.preventDefault();
+    dropZone.classList.remove('is-dragover');
+    const files = event.dataTransfer?.files;
+    if (!files || files.length === 0) {
+      return;
+    }
+    const file = files[0];
+    let assigned = false;
+    if (typeof DataTransfer !== 'undefined') {
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      fileInput.files = dataTransfer.files;
+      assigned = true;
+    }
+    if (!assigned) {
+      try {
+        fileInput.files = files;
+        assigned = true;
+      } catch (error) {
+        console.warn('Unable to populate file input from drop event', error);
+      }
+    }
+    if (!assigned) {
+      fileInput.value = '';
+    }
+    updateFileNameLabel();
+  });
+}
+
+function bindCredentialPersistence() {
+  if (!elements.rememberSecrets) {
+    return;
+  }
+  elements.rememberSecrets.addEventListener('change', () => {
+    if (!elements.rememberSecrets.checked) {
+      safeStorage('remove', STORAGE_KEY);
+    } else {
+      persistCredentialsIfNeeded();
+    }
+  });
+  [elements.apiKey, elements.licenseToken].forEach((input) => {
+    if (!input) {
+      return;
+    }
+    input.addEventListener('input', () => {
+      if (elements.rememberSecrets?.checked) {
+        persistCredentialsIfNeeded();
+      }
+    });
+  });
+}
+
+function bindExtractForm() {
+  const { form, submit, loading, result, fileInput, trigger } = elements.extract;
+  if (!form || !submit || !loading || !result || !fileInput) {
+    return;
+  }
+
+  if (trigger) {
+    trigger.addEventListener('click', () => fileInput.click());
+  }
+
+  fileInput.addEventListener('change', updateFileNameLabel);
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    clearResult(result);
+
+    const file = fileInput.files && fileInput.files[0];
+    if (!file) {
+      renderError(result, 'Select an invoice file before submitting.', 400);
+      return;
+    }
+
+    persistCredentialsIfNeeded();
+    setLoading(submit, loading, true);
+    const headers = buildHeaders();
+    const formData = new FormData();
+    formData.append('file', file);
+
+    try {
+      const payload = await sendRequest('/invoices/extract', {
+        method: 'POST',
+        headers,
+        body: formData,
+      });
+      renderExtraction(payload);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        renderError(result, error.message, error.status);
+      } else {
+        renderError(result, error?.message ?? 'Unexpected network error.', undefined);
+      }
+    } finally {
+      setLoading(submit, loading, false);
+    }
+  });
+}
+
+function bindClassifyForm() {
+  const { form, submit, loading, result, text } = elements.classify;
+  if (!form || !submit || !loading || !result || !text) {
+    return;
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    clearResult(result);
+
+    const content = text.value.trim();
+    if (!content) {
+      renderError(result, 'Provide text to classify.', 400);
+      return;
+    }
+
+    persistCredentialsIfNeeded();
+    setLoading(submit, loading, true);
+    const headers = buildHeaders({ 'Content-Type': 'application/json' });
+
+    try {
+      const payload = await sendRequest('/invoices/classify', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ text: content }),
+      });
+      renderClassification(payload);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        renderError(result, error.message, error.status);
+      } else {
+        renderError(result, error?.message ?? 'Unexpected network error.', undefined);
+      }
+    } finally {
+      setLoading(submit, loading, false);
+    }
+  });
+}
+
+function bindPredictForm() {
+  const { form, submit, loading, result, addRow, endpoint } = elements.predict;
+  if (!form || !submit || !loading || !result || !addRow || !endpoint) {
+    return;
+  }
+
+  addRow.addEventListener('click', () => addFeatureRow());
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    clearResult(result);
+
+    const { features, hasError } = collectFeatures();
+    if (hasError) {
+      renderError(result, 'Each populated row must include a feature key.', 400);
+      return;
+    }
+    if (Object.keys(features).length === 0) {
+      renderError(result, 'Add at least one feature before scoring.', 400);
+      return;
+    }
+
+    persistCredentialsIfNeeded();
+    setLoading(submit, loading, true);
+    const headers = buildHeaders({ 'Content-Type': 'application/json' });
+    const target = endpoint.value || '/invoices/predict';
+
+    try {
+      const payload = await sendRequest(target, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ features }),
+      });
+      renderPrediction(payload);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        renderError(result, error.message, error.status);
+      } else {
+        renderError(result, error?.message ?? 'Unexpected network error.', undefined);
+      }
+    } finally {
+      setLoading(submit, loading, false);
+    }
+  });
+}
+
+function initialisePredictTable() {
+  const sampleRows = [
+    ['amount', '950'],
+    ['customer_age_days', '400'],
+    ['prior_invoices', '12'],
+    ['late_ratio', '0.2'],
+  ];
+  sampleRows.forEach(([key, value]) => addFeatureRow(key, value));
+}
+
+function bindTicaForm() {
+  const { form, submit, loading, result, addItem } = elements.tica;
+  if (!form || !submit || !loading || !result || !addItem) {
+    return;
+  }
+
+  addItem.addEventListener('click', () => addTicaRow());
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    clearResult(result);
+
+    const formData = new FormData(form);
+    const invoiceNumber = normaliseString(formData.get('invoice_number'));
+    const issueDate = normaliseString(formData.get('issue_date'));
+    const exporterName = normaliseString(formData.get('exporter_name'));
+    const exporterId = normaliseString(formData.get('exporter_id'));
+    const importerName = normaliseString(formData.get('importer_name'));
+    const importerId = normaliseString(formData.get('importer_id'));
+    const currency = normaliseString(formData.get('currency'));
+    const subtotal = parseDecimalInput(formData.get('subtotal'));
+    const tax = parseDecimalInput(formData.get('tax'));
+    const total = parseDecimalInput(formData.get('total'));
+
+    if (!invoiceNumber) {
+      renderError(result, 'Invoice number is required for the TICA document.', 400);
+      return;
+    }
+    if (!issueDate) {
+      renderError(result, 'Provide an issue date (YYYY-MM-DD).', 400);
+      return;
+    }
+    if (!exporterName || !exporterId) {
+      renderError(result, 'Exporter name and identification are required.', 400);
+      return;
+    }
+    if (!importerName || !importerId) {
+      renderError(result, 'Importer name and identification are required.', 400);
+      return;
+    }
+    if (!currency) {
+      renderError(result, 'Specify the currency code.', 400);
+      return;
+    }
+    if (subtotal === null || tax === null || total === null) {
+      renderError(result, 'Subtotal, tax, and total must be numeric values.', 400);
+      return;
+    }
+
+    const { items, hasError } = collectTicaItems();
+    if (hasError) {
+      renderError(result, 'Each goods line must include a description, quantity, and unit value.', 400);
+      return;
+    }
+    if (items.length === 0) {
+      renderError(result, 'Add at least one goods line before generating the PDF.', 400);
+      return;
+    }
+
+    const payload = {
+      invoice_number: invoiceNumber,
+      issue_date: issueDate,
+      exporter_name: exporterName,
+      exporter_id: exporterId,
+      importer_name: importerName,
+      importer_id: importerId,
+      currency,
+      subtotal,
+      tax,
+      total,
+      items,
+    };
+
+    const optionalFields = {
+      exporter_address: normaliseString(formData.get('exporter_address')),
+      importer_address: normaliseString(formData.get('importer_address')),
+      customs_reference: normaliseString(formData.get('customs_reference')),
+      regime: normaliseString(formData.get('regime')),
+      incoterm: normaliseString(formData.get('incoterm')),
+      transport_mode: normaliseString(formData.get('transport_mode')),
+      destination_port: normaliseString(formData.get('destination_port')),
+      notes: normaliseString(formData.get('notes')),
+    };
+
+    Object.entries(optionalFields).forEach(([key, value]) => {
+      if (value) {
+        payload[key] = value;
+      }
+    });
+
+    persistCredentialsIfNeeded();
+    setLoading(submit, loading, true);
+    const headers = buildHeaders({ 'Content-Type': 'application/json' });
+    const filename = `tica_invoice_${invoiceNumber}.pdf`;
+
+    try {
+      const blob = await sendRequest('/invoices/tica-pdf', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+        responseType: 'binary',
+      });
+      triggerDownload(blob, filename);
+      const html = `
+        <div class="result-card">
+          <h3>PDF generated</h3>
+          <p>The customs document was downloaded as <strong>${escapeHtml(filename)}</strong>.</p>
+        </div>
+      `;
+      setResult(result, html);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        renderError(result, error.message, error.status);
+      } else {
+        renderError(result, error?.message ?? 'Unexpected network error.', undefined);
+      }
+    } finally {
+      setLoading(submit, loading, false);
+    }
+  });
+}
+
+function initialiseTicaTable() {
+  const sampleItems = [
+    {
+      description: 'Equipo de oficina',
+      hs_code: '8471.30',
+      country_of_origin: 'CN',
+      quantity: '10',
+      unit_value: '150',
+    },
+  ];
+  sampleItems.forEach((item) => addTicaRow(item));
+  ensureTicaRows();
+
+  const issueDate = document.getElementById('tica-issue-date');
+  if (issueDate && !issueDate.value) {
+    const now = new Date();
+    const iso = now.toISOString().slice(0, 10);
+    issueDate.value = iso;
+  }
+}
+
+function init() {
+  restoreCredentials();
+  bindCredentialPersistence();
+  bindExtractForm();
+  bindClassifyForm();
+  bindPredictForm();
+  bindTicaForm();
+  setupDropZone();
+  initialisePredictTable();
+  initialiseTicaTable();
+}
+
+init();

--- a/src/api/templates/invoice_portal.html
+++ b/src/api/templates/invoice_portal.html
@@ -1,0 +1,325 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Invoice Operations Portal</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='css/invoice_portal.css') }}" />
+  </head>
+  <body>
+    <header class="page-header">
+      <div class="page-header__content">
+        <h1>Invoice Operations Portal</h1>
+        <p class="page-header__subtitle">
+          Upload invoices, classify raw text, and score payment predictions with your licensed features.
+        </p>
+        <nav class="page-header__links">
+          <a href="/" class="page-header__link">API Root</a>
+          <a href="/admin" class="page-header__link">Admin Console</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="portal" id="invoice-portal">
+      <section class="card" id="credentials">
+        <h2>Authentication</h2>
+        <p class="card__lead">
+          Provide the secrets required by <code>X-API-Key</code> authentication and the optional
+          <code>X-License-Token</code> for licensed features.
+        </p>
+        <form class="form-grid" id="credentials-form">
+          <label class="form-field">
+            <span class="form-label">X-API-Key</span>
+            <input type="password" id="api-key" autocomplete="off" placeholder="Enter your API key" />
+          </label>
+          <label class="form-field">
+            <span class="form-label">X-License-Token</span>
+            <input
+              type="password"
+              id="license-token"
+              autocomplete="off"
+              placeholder="Paste your signed license token"
+            />
+          </label>
+          <label class="form-checkbox">
+            <input type="checkbox" id="remember-secrets" />
+            <span>Remember these secrets on this device</span>
+          </label>
+          <p class="form-helper">
+            Feature access is controlled by license flags: <strong>extract</strong> for file uploads,
+            <strong>classify</strong> for text classification, and <strong>predict</strong> for payment scoring.
+          </p>
+        </form>
+      </section>
+
+      <section class="card" id="extract-panel">
+        <div class="card__header">
+          <h2>Invoice Extraction</h2>
+          <span class="feature-badge" aria-label="Requires extract feature">extract</span>
+        </div>
+        <p class="card__lead">
+          Drag-and-drop or browse for a PDF or image invoice. The service will return parsed supplier, totals, line items, and raw text.
+        </p>
+        <form id="extract-form" class="card__body" novalidate>
+          <div class="drop-zone" id="extract-drop-zone">
+            <div class="drop-zone__hint">
+              <strong>Drop invoice files here</strong>
+              <span>or</span>
+            </div>
+            <button type="button" class="button button--outline" id="extract-file-button">Choose a file</button>
+            <input type="file" id="extract-file" name="file" accept=".pdf,.png,.jpg,.jpeg" />
+            <p class="drop-zone__file" id="extract-file-name">No file selected</p>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="button button--primary" id="extract-submit">Extract invoice</button>
+            <div class="loading" id="extract-loading" hidden>Processing…</div>
+          </div>
+        </form>
+        <div class="results" id="extract-result" aria-live="polite"></div>
+      </section>
+
+      <section class="card" id="classify-panel">
+        <div class="card__header">
+          <h2>Text Classification</h2>
+          <span class="feature-badge" aria-label="Requires classify feature">classify</span>
+        </div>
+        <p class="card__lead">
+          Paste raw invoice text to predict the document type. The classifier returns the best-fit label and probability.
+        </p>
+        <form id="classify-form" class="card__body" novalidate>
+          <label class="form-field">
+            <span class="form-label">Invoice text</span>
+            <textarea id="classify-text" rows="8" placeholder="Paste or type invoice contents"></textarea>
+          </label>
+          <div class="form-actions">
+            <button type="submit" class="button button--primary" id="classify-submit">Classify text</button>
+            <div class="loading" id="classify-loading" hidden>Scoring…</div>
+          </div>
+        </form>
+        <div class="results" id="classify-result" aria-live="polite"></div>
+      </section>
+
+      <section class="card" id="predict-panel">
+        <div class="card__header">
+          <h2>Payment Prediction</h2>
+          <span class="feature-badge" aria-label="Requires predict feature">predict</span>
+        </div>
+        <p class="card__lead">
+          Provide feature key/value pairs to score expected payment timing. You can target the canonical endpoint or the <code>/predict</code> alias.
+        </p>
+        <form id="predict-form" class="card__body" novalidate>
+          <div class="feature-table-wrapper">
+            <table class="feature-table" aria-describedby="predict-panel">
+              <thead>
+                <tr>
+                  <th scope="col">Feature key</th>
+                  <th scope="col">Value</th>
+                  <th scope="col" class="feature-table__actions">Actions</th>
+                </tr>
+              </thead>
+              <tbody id="feature-rows"></tbody>
+            </table>
+            <button type="button" class="button button--ghost" id="add-feature-row">Add feature</button>
+          </div>
+
+          <div class="form-grid form-grid--compact">
+            <label class="form-field">
+              <span class="form-label">Endpoint</span>
+              <select id="predict-endpoint">
+                <option value="/invoices/predict">/invoices/predict</option>
+                <option value="/predict">/predict</option>
+              </select>
+            </label>
+            <div class="form-actions form-actions--end">
+              <button type="submit" class="button button--primary" id="predict-submit">Score payment</button>
+              <div class="loading" id="predict-loading" hidden>Evaluating…</div>
+            </div>
+          </div>
+        </form>
+        <div class="results" id="predict-result" aria-live="polite"></div>
+      </section>
+
+      <section class="card card--wide" id="tica-panel">
+        <div class="card__header">
+          <h2>TICA Customs PDF</h2>
+          <span class="feature-badge" aria-label="Requires extract feature">extract</span>
+        </div>
+        <p class="card__lead">
+          Compile the information required by Costa Rica's <abbr title="Tecnología de Información para el Control Aduanero">TICA</abbr>
+          system and export a customs-ready invoice PDF.
+        </p>
+        <form id="tica-form" class="card__body" novalidate>
+          <div class="form-section">
+            <h3 class="form-section__title">Invoice metadata</h3>
+            <div class="form-grid form-grid--responsive">
+              <label class="form-field">
+                <span class="form-label">Invoice number</span>
+                <input type="text" id="tica-invoice-number" name="invoice_number" placeholder="Reference number" />
+              </label>
+              <label class="form-field">
+                <span class="form-label">Issue date</span>
+                <input type="date" id="tica-issue-date" name="issue_date" />
+              </label>
+              <label class="form-field">
+                <span class="form-label">Customs reference</span>
+                <input type="text" id="tica-customs-reference" name="customs_reference" placeholder="DUA, DUT, etc." />
+              </label>
+              <label class="form-field">
+                <span class="form-label">Regime</span>
+                <input type="text" id="tica-regime" name="regime" placeholder="Importación definitiva, tránsito..." />
+              </label>
+              <label class="form-field">
+                <span class="form-label">Incoterm</span>
+                <input type="text" id="tica-incoterm" name="incoterm" placeholder="FOB, CIF, EXW" />
+              </label>
+              <label class="form-field">
+                <span class="form-label">Transport mode</span>
+                <input type="text" id="tica-transport-mode" name="transport_mode" placeholder="Marítimo, aéreo, terrestre" />
+              </label>
+              <label class="form-field form-field--wide">
+                <span class="form-label">Destination customs office</span>
+                <input type="text" id="tica-destination-port" name="destination_port" placeholder="Puerto Caldera, Peñas Blancas..." />
+              </label>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <h3 class="form-section__title">Exporter</h3>
+            <div class="form-grid form-grid--responsive">
+              <label class="form-field">
+                <span class="form-label">Name</span>
+                <input type="text" id="tica-exporter-name" name="exporter_name" placeholder="Company or person" />
+              </label>
+              <label class="form-field">
+                <span class="form-label">Tax ID</span>
+                <input type="text" id="tica-exporter-id" name="exporter_id" placeholder="Número de identificación" />
+              </label>
+              <label class="form-field form-field--wide">
+                <span class="form-label">Address</span>
+                <textarea id="tica-exporter-address" name="exporter_address" rows="2" placeholder="Dirección completa"></textarea>
+              </label>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <h3 class="form-section__title">Importer</h3>
+            <div class="form-grid form-grid--responsive">
+              <label class="form-field">
+                <span class="form-label">Name</span>
+                <input type="text" id="tica-importer-name" name="importer_name" placeholder="Destinatario" />
+              </label>
+              <label class="form-field">
+                <span class="form-label">Tax ID</span>
+                <input type="text" id="tica-importer-id" name="importer_id" placeholder="Número de identificación" />
+              </label>
+              <label class="form-field form-field--wide">
+                <span class="form-label">Address</span>
+                <textarea id="tica-importer-address" name="importer_address" rows="2" placeholder="Dirección completa"></textarea>
+              </label>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <h3 class="form-section__title">Goods declaration</h3>
+            <div class="table-scroll" role="group" aria-label="Goods listed for the customs document">
+              <table class="feature-table feature-table--tight" aria-describedby="tica-panel">
+                <thead>
+                  <tr>
+                    <th scope="col">Description</th>
+                    <th scope="col">HS code</th>
+                    <th scope="col">Country of origin</th>
+                    <th scope="col">Quantity</th>
+                    <th scope="col">Unit value</th>
+                    <th scope="col">Total value</th>
+                    <th scope="col" class="feature-table__actions">Actions</th>
+                  </tr>
+                </thead>
+                <tbody id="tica-rows"></tbody>
+              </table>
+            </div>
+            <p class="form-helper">Leave total value blank to calculate quantity × unit value automatically.</p>
+            <button type="button" class="button button--ghost" id="add-tica-item">Add goods line</button>
+          </div>
+
+          <div class="form-section">
+            <h3 class="form-section__title">Totals &amp; notes</h3>
+            <div class="form-grid form-grid--responsive">
+              <label class="form-field">
+                <span class="form-label">Currency</span>
+                <input type="text" id="tica-currency" name="currency" placeholder="USD" />
+              </label>
+              <label class="form-field">
+                <span class="form-label">Subtotal</span>
+                <input type="number" id="tica-subtotal" name="subtotal" step="0.01" min="0" />
+              </label>
+              <label class="form-field">
+                <span class="form-label">Tax</span>
+                <input type="number" id="tica-tax" name="tax" step="0.01" min="0" />
+              </label>
+              <label class="form-field">
+                <span class="form-label">Total</span>
+                <input type="number" id="tica-total" name="total" step="0.01" min="0" />
+              </label>
+              <label class="form-field form-field--wide">
+                <span class="form-label">Notes</span>
+                <textarea id="tica-notes" name="notes" rows="3" placeholder="Instrucciones o sellos especiales"></textarea>
+              </label>
+            </div>
+          </div>
+
+          <div class="form-actions">
+            <button type="submit" class="button button--primary" id="tica-submit">Generate TICA PDF</button>
+            <div class="loading" id="tica-loading" hidden>Generating…</div>
+          </div>
+        </form>
+        <div class="results" id="tica-result" aria-live="polite"></div>
+      </section>
+    </main>
+
+    <template id="feature-row-template">
+      <tr class="feature-row">
+        <td data-label="Feature key">
+          <input type="text" class="feature-key" placeholder="e.g. amount" />
+        </td>
+        <td data-label="Value">
+          <input type="text" class="feature-value" placeholder="e.g. 950" />
+        </td>
+        <td class="feature-table__actions" data-label="Actions">
+          <button type="button" class="button button--icon remove-feature" aria-label="Remove feature row">
+            ✕
+          </button>
+        </td>
+      </tr>
+    </template>
+
+    <template id="tica-row-template">
+      <tr class="tica-row">
+        <td data-label="Description">
+          <textarea class="tica-description" rows="2" placeholder="Describe the goods"></textarea>
+        </td>
+        <td data-label="HS code">
+          <input type="text" class="tica-hs" placeholder="e.g. 4810.19" />
+        </td>
+        <td data-label="Country of origin">
+          <input type="text" class="tica-origin" placeholder="CR, MX, CN" />
+        </td>
+        <td data-label="Quantity">
+          <input type="number" class="tica-quantity" step="0.001" min="0" />
+        </td>
+        <td data-label="Unit value">
+          <input type="number" class="tica-unit-value" step="0.01" min="0" />
+        </td>
+        <td data-label="Total value">
+          <input type="number" class="tica-total-value" step="0.01" min="0" />
+        </td>
+        <td class="feature-table__actions" data-label="Actions">
+          <button type="button" class="button button--icon remove-tica-item" aria-label="Remove goods line">
+            ✕
+          </button>
+        </td>
+      </tr>
+    </template>
+
+    <script src="{{ url_for('static', path='js/invoice_portal.js') }}" type="module"></script>
+  </body>
+</html>

--- a/tests/test_invoice_portal.py
+++ b/tests/test_invoice_portal.py
@@ -1,0 +1,111 @@
+"""Integration tests for the invoice portal template and assets."""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from fastapi import Request
+from fastapi.responses import StreamingResponse
+from starlette.templating import _TemplateResponse
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(PROJECT_ROOT / "src"))
+
+os.environ.setdefault("API_KEY", "portal-test-secret")
+
+from api.license_validator import LicenseClaims
+from api.main import app, invoice_portal  # noqa: E402  pylint: disable=wrong-import-position
+from api.routers import tica
+
+
+def _build_request() -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/portal",
+        "root_path": "",
+        "app": app,
+        "headers": [],
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("testclient", 12345),
+    }
+    return Request(scope)
+
+
+def test_invoice_portal_template_served() -> None:
+    request = _build_request()
+    response = invoice_portal(request)
+
+    assert isinstance(response, _TemplateResponse)
+    assert response.template.name == "invoice_portal.html"
+    assert response.context["request"] is request
+
+    rendered = response.body.decode("utf-8")
+    assert "Invoice Operations Portal" in rendered
+    assert "/static/js/invoice_portal.js" in rendered
+    assert "TICA Customs PDF" in rendered
+    assert "id=\"tica-form\"" in rendered
+
+
+def test_invoice_portal_static_asset_paths_resolve() -> None:
+    css_path = app.url_path_for("static", path="css/invoice_portal.css")
+    js_path = app.url_path_for("static", path="js/invoice_portal.js")
+
+    assert css_path == "/static/css/invoice_portal.css"
+    assert js_path == "/static/js/invoice_portal.js"
+
+    css_file = PROJECT_ROOT / "src" / "api" / "static" / "css" / "invoice_portal.css"
+    js_file = PROJECT_ROOT / "src" / "api" / "static" / "js" / "invoice_portal.js"
+
+    assert css_file.exists()
+    assert js_file.exists()
+
+
+async def _collect_body(response: StreamingResponse) -> bytes:
+    chunks: list[bytes] = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def test_tica_pdf_generation_returns_pdf() -> None:
+    payload = tica.TicaInvoicePayload(
+        invoice_number="TICA-001",
+        issue_date="2024-06-01",
+        exporter_name="Exportadora Centroamericana",
+        exporter_id="301230123",
+        exporter_address="San José, Costa Rica",
+        importer_name="Cliente Internacional",
+        importer_id="99887766",
+        importer_address="Panamá City, Panamá",
+        incoterm="FOB",
+        transport_mode="Marítimo",
+        destination_port="Puerto Moín",
+        currency="USD",
+        subtotal=5000,
+        tax=650,
+        total=5650,
+        items=[
+            tica.TicaInvoiceItem(
+                description="Equipo médico especializado",
+                quantity=5,
+                unit_value=1000,
+                hs_code="9018.90",
+                country_of_origin="DE",
+            )
+        ],
+    )
+
+    claims = LicenseClaims(raw={"features": ["extract"]}, features=frozenset({"extract"}))
+    response = tica.generate_tica_invoice_pdf(payload, claims)
+
+    assert isinstance(response, StreamingResponse)
+    assert response.media_type == "application/pdf"
+    disposition = response.headers.get("Content-Disposition", "")
+    assert "tica_invoice_TICA-001.pdf" in disposition
+
+    body = asyncio.run(_collect_body(response))
+    assert body.startswith(b"%PDF")
+    assert len(body) > 500


### PR DESCRIPTION
## Summary
- register the invoice TICA PDF generator router and build customs-ready PDFs with a pure-Python builder
- expand the portal markup, styling, and scripts to add a mobile-friendly TICA section alongside existing extraction, classification, and prediction tools
- document the new workflow and update tests to cover the template changes and PDF endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d380c35a808329b3472c89de9ccc44