### PR TITLE
Adjust textarea sizing for invoice portal

### DIFF
--- a/src/api/static/css/invoice_portal.css
+++ b/src/api/static/css/invoice_portal.css
@@ -409,7 +409,19 @@ a:focus {
 
 textarea {
   resize: vertical;
+  line-height: 1.5;
+}
+
+#classify-text {
   min-height: 160px;
+}
+
+.form-field textarea[rows='2'] {
+  min-height: calc(2 * 1.5em + 20px);
+}
+
+.form-field textarea[rows='3'] {
+  min-height: calc(3 * 1.5em + 20px);
 }
 
 .drop-zone {


### PR DESCRIPTION
## Summary
- scope the tall textarea minimum height to the long-form classifier input
- add proportional minimum heights for short metadata textareas so their rows render as expected

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6c357f4d08329b3edc2e0906de9fa