### PR TITLE
Refine invoice upload drop zone accessibility

### DIFF
--- a/src/api/static/css/invoice_portal.css
+++ b/src/api/static/css/invoice_portal.css
@@ -426,6 +426,9 @@ textarea {
   background: var(--color-surface-alt);
   transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
   cursor: pointer;
+  appearance: none;
+  width: 100%;
+  color: inherit;
 }
 
 .drop-zone.is-dragover {
@@ -450,6 +453,13 @@ textarea {
   inset: 0;
   opacity: 0;
   cursor: pointer;
+  pointer-events: none;
+}
+
+.drop-zone__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   pointer-events: none;
 }
 

--- a/src/api/static/js/invoice_portal.js
+++ b/src/api/static/js/invoice_portal.js
@@ -551,17 +551,8 @@ function setupDropZone() {
   const { dropZone, fileInput } = elements.extract;
   if (!dropZone || !fileInput) return;
   dropZone.addEventListener('click', (event) => {
-    const target = event.target;
-    if (target instanceof HTMLElement && target.closest('button')) {
-      return;
-    }
+    event.preventDefault();
     fileInput.click();
-  });
-  dropZone.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      fileInput.click();
-    }
   });
   dropZone.addEventListener('dragover', (event) => {
     event.preventDefault();
@@ -618,12 +609,8 @@ function bindCredentialPersistence() {
 }
 
 function bindExtractForm() {
-  const { form, submit, loading, result, fileInput, trigger } = elements.extract;
+  const { form, submit, loading, result, fileInput } = elements.extract;
   if (!form || !submit || !loading || !result || !fileInput) return;
-
-  if (trigger) {
-    trigger.addEventListener('click', () => fileInput.click());
-  }
 
   fileInput.addEventListener('change', updateFileNameLabel);
 

--- a/src/api/templates/invoice_portal.html
+++ b/src/api/templates/invoice_portal.html
@@ -85,15 +85,15 @@
         </div>
         <div class="card__body card__body--spacious">
           <form id="extract-form" class="card__section" novalidate>
-            <div class="drop-zone" id="extract-drop-zone" role="button" tabindex="0" aria-label="Upload an invoice file">
-              <div class="drop-zone__hint">
+            <button type="button" class="drop-zone" id="extract-drop-zone" aria-labelledby="extract-drop-zone-label" aria-describedby="extract-file-name">
+              <div class="drop-zone__hint" id="extract-drop-zone-label">
                 <strong>Drop invoice files here</strong>
                 <span>or</span>
               </div>
-              <button type="button" class="button button--outline" id="extract-file-button">Choose a file</button>
+              <span class="button button--outline drop-zone__action" id="extract-file-button">Choose a file</span>
               <input type="file" id="extract-file" name="file" accept=".pdf,.png,.jpg,.jpeg" aria-hidden="true" tabindex="-1" />
               <p class="drop-zone__file" id="extract-file-name">No file selected</p>
-            </div>
+            </button>
             <div class="form-actions">
               <button type="submit" class="button button--primary" id="extract-submit">Extract invoice</button>
               <div class="loading" id="extract-loading" aria-live="polite" hidden>Processing…</div>


### PR DESCRIPTION
## Summary
- convert the invoice extraction drop zone into a single button control for uploads
- update client scripts to target the unified control and avoid duplicate activation
- tweak styles so the drop zone button retains its original appearance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6c3582db8832988e2b9f10e566b2b