### PR TITLE
Improve OCR amount normalization heuristics

### DIFF
--- a/src/ai_invoice/ocr/postprocess.py
+++ b/src/ai_invoice/ocr/postprocess.py
@@ -8,8 +8,60 @@ def clean_text(txt: str) -> str:
     return re.sub(r"[ \t]+", " ", txt)
 
 
+def _separators(number: str) -> tuple[str | None, str | None]:
+    """Infer decimal and thousands separators for *number*.
+
+    When both a comma and a dot are present we assume the last separator is the
+    decimal marker. With only a single separator we treat it as a decimal marker
+    if it is followed by exactly two digits, otherwise it is classified as a
+    thousands separator.
+    """
+
+    comma_pos = number.rfind(",")
+    dot_pos = number.rfind(".")
+
+    if comma_pos != -1 and dot_pos != -1:
+        if comma_pos > dot_pos:
+            return ",", "."
+        return ".", ","
+
+    if comma_pos != -1:
+        decimals = len(number) - comma_pos - 1
+        if decimals == 2:
+            return ",", None
+        return None, ","
+
+    if dot_pos != -1:
+        decimals = len(number) - dot_pos - 1
+        if decimals == 2:
+            return ".", None
+        return None, "."
+
+    return None, None
+
+
 def normalize_amount(txt: str) -> float | None:
-    match = re.search(r"([\-]?\d{1,3}(?:[.,]\d{3})*(?:[.,]\d{2}))", txt)
+    match = re.search(
+        r"([\-]?\d{1,3}(?:[.,]\d{3})*(?:[.,]\d{2})|[\-]?\d+(?:[.,]\d{2}))",
+        txt,
+    )
     if not match:
         return None
-    return float(match.group(1).replace(",", ""))
+
+    number = match.group(1)
+    number = number.replace(" ", "")
+
+    decimal_sep, thousands_sep = _separators(number)
+
+    if thousands_sep:
+        number = number.replace(thousands_sep, "")
+
+    if decimal_sep and decimal_sep != ".":
+        number = number.replace(decimal_sep, ".")
+    elif not decimal_sep:
+        number = number.replace(",", "").replace(".", "")
+
+    try:
+        return float(number)
+    except ValueError:
+        return None

--- a/tests/test_ocr_postprocess.py
+++ b/tests/test_ocr_postprocess.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from ai_invoice.nlp_extract.parser import parse_structured
+from ai_invoice.ocr.postprocess import normalize_amount
+
+
+def test_normalize_amount_us_format():
+    assert normalize_amount("Total 1,234.56") == 1234.56
+
+
+def test_normalize_amount_eu_format():
+    assert normalize_amount("Total 1.234,56") == 1234.56
+
+
+def test_parse_structured_uses_normalized_total_us():
+    extraction = parse_structured("Invoice\nTotal: 1,234.56")
+    assert extraction.total == 1234.56
+
+
+def test_parse_structured_uses_normalized_total_eu():
+    extraction = parse_structured("Invoice\nTotal: 1.234,56")
+    assert extraction.total == 1234.56


### PR DESCRIPTION
## Summary
- refine the OCR amount normalizer to infer decimal and thousands separators before conversion
- add unit tests covering US- and EU-style totals
- verify that parse_structured surfaces normalized totals for both formats

## Testing
- PYTHONPATH=src pytest tests/test_ocr_postprocess.py *(fails: missing dependency pydantic cannot be installed in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c7a64da483299ad03e6a3493c879