### PR TITLE
Switch API middleware to Ed25519 license verification

### DIFF
--- a/src/api/license_validator.py
+++ b/src/api/license_validator.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import base64
-import hashlib
-import json
-import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, Sequence
@@ -11,12 +7,10 @@ from typing import Any, Callable, Mapping, Sequence
 from fastapi import HTTPException, Request, status
 
 from ai_invoice.config import Settings, settings
+from ai_invoice.license import LicensePayload
 
 
 HEADER_NAME = "X-License"
-_DIGEST_INFO_SHA256 = bytes.fromhex(
-    "3031300d060960864801650304020105000420"
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +19,7 @@ class LicenseClaims:
 
     raw: Mapping[str, Any]
     features: frozenset[str]
+    payload: LicensePayload | None = None
 
     def __getitem__(self, item: str) -> Any:
         return self.raw[item]
@@ -34,7 +29,23 @@ class LicenseClaims:
 
     @property
     def expires_at(self) -> datetime | None:
-        exp = self.raw.get("exp")
+        if self.payload is not None:
+            return self.payload.expires_at
+
+        exp = self.raw.get("expires_at") or self.raw.get("exp")
+        if isinstance(exp, datetime):
+            if exp.tzinfo is None:
+                exp = exp.replace(tzinfo=timezone.utc)
+            return exp.astimezone(timezone.utc)
+        if isinstance(exp, str):
+            try:
+                normalized = exp.replace("Z", "+00:00")
+                dt = datetime.fromisoformat(normalized)
+            except ValueError:
+                return None
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
         if isinstance(exp, (int, float)):
             return datetime.fromtimestamp(exp, tz=timezone.utc)
         return None
@@ -43,23 +54,8 @@ class LicenseClaims:
         return feature in self.features
 
 
-def _b64url_decode(data: str) -> bytes:
-    padding = "=" * ((4 - len(data) % 4) % 4)
-    return base64.urlsafe_b64decode(data + padding)
-
-
-def _normalize_features(value: Any) -> frozenset[str]:
-    if isinstance(value, str):
-        candidates: Sequence[str] = [value]
-    elif isinstance(value, Sequence):
-        candidates = value
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="License payload is missing feature permissions.",
-        )
-
-    normalized = [item.strip() for item in candidates if isinstance(item, str) and item.strip()]
+def _normalize_features(values: Sequence[str]) -> frozenset[str]:
+    normalized = [item.strip() for item in values if isinstance(item, str) and item.strip()]
     if not normalized:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -68,155 +64,26 @@ def _normalize_features(value: Any) -> frozenset[str]:
     return frozenset(normalized)
 
 
-def _read_length(buffer: bytes, offset: int) -> tuple[int, int]:
-    first = buffer[offset]
-    offset += 1
-    if first & 0x80 == 0:
-        return first, offset
-    num_bytes = first & 0x7F
-    length = int.from_bytes(buffer[offset : offset + num_bytes], "big")
-    offset += num_bytes
-    return length, offset
-
-
-def _read_der_element(buffer: bytes, offset: int) -> tuple[int, bytes, int]:
-    tag = buffer[offset]
-    offset += 1
-    length, offset = _read_length(buffer, offset)
-    value = buffer[offset : offset + length]
-    offset += length
-    return tag, value, offset
-
-
-def _load_rsa_public_numbers(pem: str) -> tuple[int, int]:
-    body = "".join(line.strip() for line in pem.strip().splitlines() if "-----" not in line)
-    der = base64.b64decode(body)
-
-    tag, value, _ = _read_der_element(der, 0)
-    if tag != 0x30:
-        raise ValueError("Invalid public key: expected SEQUENCE")
-
-    inner_offset = 0
-    alg_tag, alg_value, inner_offset = _read_der_element(value, inner_offset)
-    if alg_tag != 0x30:
-        raise ValueError("Invalid public key: missing algorithm identifier")
-    bitstring_tag, bitstring_value, _ = _read_der_element(value, inner_offset)
-    if bitstring_tag != 0x03 or not bitstring_value:
-        raise ValueError("Invalid public key: missing public key bit string")
-    if bitstring_value[0] != 0x00:
-        raise ValueError("Invalid public key: unexpected padding bits")
-
-    rsa_der = bitstring_value[1:]
-    rsa_tag, rsa_value, _ = _read_der_element(rsa_der, 0)
-    if rsa_tag != 0x30:
-        raise ValueError("Invalid public key: malformed RSA structure")
-
-    offset = 0
-    mod_tag, mod_value, offset = _read_der_element(rsa_value, offset)
-    exp_tag, exp_value, _ = _read_der_element(rsa_value, offset)
-    if mod_tag != 0x02 or exp_tag != 0x02:
-        raise ValueError("Invalid public key: malformed RSA integers")
-
-    modulus = int.from_bytes(mod_value, "big")
-    exponent = int.from_bytes(exp_value, "big")
-    return modulus, exponent
-
-
-def _verify_rs256(signing_input: bytes, signature: bytes, modulus: int, exponent: int) -> bool:
-    expected_hash = _DIGEST_INFO_SHA256 + hashlib.sha256(signing_input).digest()
-
-    modulus_len = (modulus.bit_length() + 7) // 8
-    signature_int = int.from_bytes(signature, "big")
-    recovered = pow(signature_int, exponent, modulus)
-    recovered_bytes = recovered.to_bytes(modulus_len, "big")
-
-    if len(recovered_bytes) < len(expected_hash) + 11:
-        return False
-    if not recovered_bytes.startswith(b"\x00\x01"):
-        return False
-    try:
-        separator_index = recovered_bytes.index(b"\x00", 2)
-    except ValueError:
-        return False
-    padding = recovered_bytes[2:separator_index]
-    if len(padding) < 8 or any(byte != 0xFF for byte in padding):
-        return False
-    return recovered_bytes[separator_index + 1 :] == expected_hash
-
-
-def _parse_jwt_segments(token: str) -> tuple[str, str, str]:
-    parts = token.split(".")
-    if len(parts) != 3:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid license token.")
-    return parts[0], parts[1], parts[2]
-
-
-def _decode_json(segment: str) -> Mapping[str, Any]:
-    try:
-        data = json.loads(_b64url_decode(segment))
-    except (json.JSONDecodeError, ValueError):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid license token.")
-    if not isinstance(data, Mapping):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid license token.")
-    return data
-
-
-def validate_license_token(
-    token: str | None,
-    *,
-    config: Settings | None = None,
+def build_license_claims(
+    payload: LicensePayload, *, config: Settings | None = None
 ) -> LicenseClaims:
-    """Validate a signed license token and return normalized claims."""
-
-    if not token:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing license token.")
+    """Normalize a verified payload into the API's claim structure."""
 
     cfg = config or settings
-    key = getattr(cfg, "license_public_key", None)
-    if not key:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="License verification is not configured.",
-        )
 
-    header_segment, payload_segment, signature_segment = _parse_jwt_segments(token)
-    header = _decode_json(header_segment)
-    payload = _decode_json(payload_segment)
+    features = _normalize_features(payload.features)
 
-    algorithm = (header.get("alg") or "").upper()
-    expected_alg = (getattr(cfg, "license_algorithm", "RS256") or "RS256").upper()
-    if algorithm != expected_alg:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid license token.")
-
-    try:
-        modulus, exponent = _load_rsa_public_numbers(key)
-    except ValueError as exc:  # pragma: no cover - defensive branch
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Invalid license key.") from exc
-
-    signature = _b64url_decode(signature_segment)
-    signing_input = f"{header_segment}.{payload_segment}".encode("ascii")
-    if not _verify_rs256(signing_input, signature, modulus, exponent):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid license token.")
-
-    exp = payload.get("exp")
-    if not isinstance(exp, (int, float)):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="License token missing expiry.")
-    if exp < time.time():
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="License token expired.")
-
-    jti = payload.get("jti")
-    if not isinstance(jti, str) or not jti.strip():
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="License token missing identifier.")
-    if jti in getattr(cfg, "license_revoked_jtis", frozenset()):
+    revoked_ids = getattr(cfg, "license_revoked_jtis", frozenset())
+    if payload.token_id in revoked_ids:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="License token revoked.")
 
-    subject = payload.get("sub")
-    if isinstance(subject, str) and subject in getattr(cfg, "license_revoked_subjects", frozenset()):
+    revoked_subjects = getattr(cfg, "license_revoked_subjects", frozenset())
+    tenant_id = payload.tenant.id
+    if tenant_id in revoked_subjects:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="License token revoked.")
 
-    features = _normalize_features(payload.get("features"))
-
-    return LicenseClaims(raw=dict(payload), features=features)
+    raw = payload.model_dump(mode="json")
+    return LicenseClaims(raw=raw, features=features, payload=payload)
 
 
 def ensure_feature(claims: LicenseClaims | None, feature: str) -> LicenseClaims:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -6,10 +6,10 @@ import logging
 import os
 import subprocess
 import sys
-import tempfile
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path
+from typing import Any, Sequence
 
 import pytest
 from fastapi import HTTPException
@@ -25,48 +25,12 @@ from ai_invoice.config import settings
 from api.license_validator import HEADER_NAME, LicenseClaims
 from api.middleware import APIKeyAndLoggingMiddleware
 from api.routers.invoices import extract_invoice_endpoint
+from api.security import reset_license_verifier_cache
 
 
 pytestmark = pytest.mark.anyio()
 
-PRIVATE_KEY = """-----BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC2twz8UXSIGzHz
-dEWJyPq3kCsDDovC+ohQ+mBO1ZCEAsmdWVn8QRdHQeNEnrdYA270YLgx+WivgayH
-6Wje0WwuBzL818u2A6GQeBb60moUAXPJ80wNF+MT/0Bc3u2T5HS7Aa4OONrIh/QG
-xLNq4S5c5a9KWYWiMizgSKcVvhhG9u9H3FSvBCgculS0Ktl9xOkhzPhKtoPHGs8f
-tfiOKNl/6nH/nvKHJagKaNSIMNBctHx4KMzj8vplehkfAn7iC7inuG+9pqB+CWfm
-VFafwkxnajxC+Y+THyhcFdsAw1js1JYdwn/Wcd9wDFSYItMzivy199bnuKqlbusN
-/6LRZsGhAgMBAAECggEAFdzP0TYm6S1F3BFWy76QX1wBBYfdScqD+pqG4Q/1T5Js
-0ObS2VfpguV7neeW3RFmGpgjGhmzgMKVpBqV6Ylp9hT28SGaFrCXCawQ5di9CCFH
-W0wBFtT7nxYs+5/SEh7lJ8Yy7zE23oVD+fZZ2IlSrJtwDseo8Ygq7fhLg9K/4Wex
-FfPKad6oj3+3pC5f1MmQJhmJU8hxkz05UWlz/Exl4bNbDCGyu24TEeV2wVUKVlMt
-oaRIKLwKZA8HN0Ia1arHzdml+iMwMTMF5FIWSjZ+xyNSxdIn4OGdXXpyMLOn3lIQ
-GJA8HTnuUh2yW5jXImKsMVZo9v29vdWHpDFYT3J+0QKBgQDxfSJaTxgZ+JLXhjQp
-gWhmtVkF6qVDFoIkxSXRPwJknd/m9z3xAuPh4gIq4n/rDiQ/6WLb47SCY6Z4XNGS
-Xsxj2uEyzIBMJ1yo5l7/SIpoSzqXcPJML8VeCLZlJj7S5ZDaBgbyboEW9BYuRHtY
-IA6VXHdGEgtkeO4DO7x7lBkwmQKBgQDBscoFBz7jVE5M2+RCLSuVbSP90tENHq84
-yGhDhfMwTJTB2GwkgCRHUl/NWAiLSmJe4/9x/fXgdlNlAee6oRT1PeDZhrot95ZC
-IoXT6Dzk8kYXOQtg1VeDbq3YdI/REtkRQNS9rqZbfqmSXdVO0UEEvAxcheZyEmDI
-bNcrS1jWSQKBgGPahUjoaaPbiAR8Zrc+3keR9xSeOOWrufawWnnSXw/xw/KCC2fL
-9SSiypim/ZPZTh3rSEh6OFquD9i3MKUgc81aZUIXE3np0MO6Nk/C1BBaAwk518au
-/iJq4dijXtjfueydD2RRUymFlmJdSM9gugcCrAMaVQGfi3Nk0QQcceoJAoGALeDR
-q/06XRgj77qJx07xqtQOGVns4EGrWTTG1W+N2ZvaBEwh2Uds0GPngzjd1ThKMpWo
-dLSln4QHXr5jx+XNlAUTFBMAWFDzizioIDg67DOifG+rjUUbFGuLy+BYDDp9pcOI
-YGFU0AkhWyTUmHWiA+ASwXuJyO0ndXGqSXvwT9kCgYEAojbJNLGSo8rul3nVbx4L
-NmfZYBBuAJeiDDh14wwtj9d+Z6viUwLpPkeS2uqs/S762h6WLdFOvCDgJPXeTs6y
-B/jo0PV40IszgLjjo7DGO9Esamo68Na/kSWOFt10EQUB5fvPYF+8trtUzCB0pfXn
-EvsUYXvDLEPJKdSMe3PMEpM=
------END PRIVATE KEY-----"""
-
-PUBLIC_KEY = """-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtrcM/FF0iBsx83RFicj6
-t5ArAw6LwvqIUPpgTtWQhALJnVlZ/EEXR0HjRJ63WANu9GC4Mflor4Gsh+lo3tFs
-Lgcy/NfLtgOhkHgW+tJqFAFzyfNMDRfjE/9AXN7tk+R0uwGuDjjayIf0BsSzauEu
-XOWvSlmFojIs4EinFb4YRvbvR9xUrwQoHLpUtCrZfcTpIcz4SraDxxrPH7X4jijZ
-f+px/57yhyWoCmjUiDDQXLR8eCjM4/L6ZXoZHwJ+4gu4p7hvvaagfgln5lRWn8JM
-Z2o8QvmPkx8oXBXbAMNY7NSWHcJ/1nHfcAxUmCLTM4r8tffW57iqpW7rDf+i0WbB
-oQIDAQAB
------END PUBLIC KEY-----"""
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 DEFAULT_FEATURES = (
     "extract",
@@ -78,57 +42,85 @@ DEFAULT_FEATURES = (
 )
 
 
+def _generate_test_keypair(tmp_path: Path) -> tuple[Path, Path]:
+    private_path = tmp_path / "private.pem"
+    public_path = tmp_path / "public.pem"
+
+    subprocess.run([
+        "openssl",
+        "genpkey",
+        "-algorithm",
+        "ed25519",
+        "-out",
+        str(private_path),
+    ], check=True)
+    subprocess.run([
+        "openssl",
+        "pkey",
+        "-in",
+        str(private_path),
+        "-pubout",
+        "-out",
+        str(public_path),
+    ], check=True)
+
+    return private_path, public_path
+
+
+def _normalize_timestamp(value: datetime | str) -> str:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return value
+
+
+def _issue_token(
+    private_key: Path,
+    *,
+    features: Sequence[str] | None = None,
+    expires: datetime | str | None = None,
+    issued_at: datetime | str | None = None,
+    tenant_id: str = "tenant-123",
+) -> str:
+    expiration = expires or (datetime.now(timezone.utc) + timedelta(minutes=5))
+    cmd = [
+        sys.executable,
+        str(PROJECT_ROOT / "scripts" / "generate_license.py"),
+        "--private-key",
+        str(private_key),
+        "--tenant-id",
+        tenant_id,
+        "--tenant-name",
+        "Integration Tests",
+        "--expires",
+        _normalize_timestamp(expiration),
+    ]
+
+    feature_list = list(features or DEFAULT_FEATURES)
+    for feature in feature_list:
+        cmd.extend(["--feature", feature])
+
+    if issued_at is not None:
+        cmd.extend(["--issued-at", _normalize_timestamp(issued_at)])
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    payload = json.loads(result.stdout)
+    return payload["token"]
+
+
+def _decode_artifact(token: str) -> dict[str, Any]:
+    padding = "=" * ((4 - len(token) % 4) % 4)
+    raw = base64.urlsafe_b64decode(token + padding)
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise TypeError("Decoded license artifact must be a mapping.")
+    return data
+
+
 @pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
-
-
-def _b64url(data: bytes) -> str:
-    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
-
-
-def _openssl_sign(payload: bytes) -> bytes:
-    with tempfile.NamedTemporaryFile("w", delete=False) as key_file:
-        key_file.write(PRIVATE_KEY)
-        key_path = key_file.name
-    with tempfile.NamedTemporaryFile("wb", delete=False) as data_file:
-        data_file.write(payload)
-        data_path = data_file.name
-    with tempfile.NamedTemporaryFile(delete=False) as sig_file:
-        sig_path = sig_file.name
-    try:
-        subprocess.run(
-            ["openssl", "dgst", "-sha256", "-sign", key_path, "-out", sig_path, data_path],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        signature = Path(sig_path).read_bytes()
-    finally:
-        for path in (key_path, data_path, sig_path):
-            try:
-                os.unlink(path)
-            except OSError:
-                pass
-    return signature
-
-
-def _issue_token(**overrides: object) -> str:
-    now = datetime.now(timezone.utc)
-    payload: dict[str, object] = {
-        "sub": overrides.pop("sub", "tenant-123"),
-        "jti": overrides.pop("jti", "token-123"),
-        "iat": int(now.timestamp()),
-        "exp": int((now + timedelta(minutes=5)).timestamp()),
-        "features": overrides.pop("features", DEFAULT_FEATURES),
-    }
-    payload.update(overrides)
-    header = {"alg": "RS256", "typ": "JWT"}
-    header_segment = _b64url(json.dumps(header, separators=(',', ':'), sort_keys=True).encode("utf-8"))
-    payload_segment = _b64url(json.dumps(payload, separators=(',', ':'), sort_keys=True).encode("utf-8"))
-    signing_input = f"{header_segment}.{payload_segment}".encode("ascii")
-    signature_segment = _b64url(_openssl_sign(signing_input))
-    return f"{header_segment}.{payload_segment}.{signature_segment}"
 
 
 def _claims(*features: str) -> LicenseClaims:
@@ -173,22 +165,26 @@ def api_key_guard() -> None:
 
 
 @pytest.fixture()
-def license_guard() -> None:
+def license_guard(tmp_path: Path) -> Path:
+    private_key, public_key = _generate_test_keypair(tmp_path)
+    previous_path = settings.license_public_key_path
     previous_key = settings.license_public_key
-    previous_alg = settings.license_algorithm
     previous_revoked = settings.license_revoked_jtis
     previous_subjects = settings.license_revoked_subjects
-    settings.license_public_key = PUBLIC_KEY
-    settings.license_algorithm = "RS256"
+
+    settings.license_public_key_path = str(public_key)
+    settings.license_public_key = public_key.read_text(encoding="utf-8").strip() or None
     settings.license_revoked_jtis = frozenset()
     settings.license_revoked_subjects = frozenset()
+    reset_license_verifier_cache()
     try:
-        yield
+        yield private_key
     finally:
+        settings.license_public_key_path = previous_path
         settings.license_public_key = previous_key
-        settings.license_algorithm = previous_alg
         settings.license_revoked_jtis = previous_revoked
         settings.license_revoked_subjects = previous_subjects
+        reset_license_verifier_cache()
 
 
 @pytest.fixture()
@@ -215,7 +211,7 @@ async def test_missing_api_key_is_rejected(
         called = True
         return Response("ok")
 
-    token = _issue_token()
+    token = _issue_token(license_guard)
     request = _build_request(headers=[(HEADER_NAME.lower().encode(), token.encode())])
     with caplog.at_level(logging.INFO, logger="ai_invoice.api.middleware"):
         response = await middleware.dispatch(request, call_next)
@@ -242,8 +238,10 @@ async def test_missing_license_token_is_rejected(api_key_guard, license_guard) -
 
 async def test_health_request_without_license_does_not_raise(rate_limit_guard) -> None:
     previous_api_key = settings.api_key
+    previous_license_path = settings.license_public_key_path
     previous_license_key = settings.license_public_key
     settings.api_key = None
+    settings.license_public_key_path = None
     settings.license_public_key = None
     try:
         middleware = _middleware()
@@ -255,6 +253,7 @@ async def test_health_request_without_license_does_not_raise(rate_limit_guard) -
         response = await middleware.dispatch(request, call_next)
     finally:
         settings.api_key = previous_api_key
+        settings.license_public_key_path = previous_license_path
         settings.license_public_key = previous_license_key
 
     assert response.status_code == 200
@@ -270,7 +269,7 @@ async def test_authorized_request_logs(
         return Response("ok", media_type="application/json")
 
     middleware = _middleware()
-    token = _issue_token()
+    token = _issue_token(license_guard)
     headers = [
         (b"x-api-key", b"test-secret"),
         (HEADER_NAME.lower().encode(), token.encode()),
@@ -294,7 +293,9 @@ async def test_expired_license_token_rejected(api_key_guard, license_guard) -> N
     async def call_next(request: Request) -> Response:  # pragma: no cover - unreachable
         return Response("ok")
 
-    expired_token = _issue_token(exp=int((datetime.now(timezone.utc) - timedelta(minutes=1)).timestamp()))
+    issued_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+    expires = datetime.now(timezone.utc) - timedelta(minutes=1)
+    expired_token = _issue_token(license_guard, issued_at=issued_at, expires=expires)
     headers = [
         (b"x-api-key", b"test-secret"),
         (HEADER_NAME.lower().encode(), expired_token.encode()),
@@ -308,12 +309,14 @@ async def test_expired_license_token_rejected(api_key_guard, license_guard) -> N
 
 async def test_revoked_license_token_rejected(api_key_guard, license_guard) -> None:
     middleware = _middleware()
-    settings.license_revoked_jtis = frozenset({"revoked"})
 
     async def call_next(request: Request) -> Response:  # pragma: no cover - unreachable
         return Response("ok")
 
-    revoked_token = _issue_token(jti="revoked")
+    revoked_token = _issue_token(license_guard)
+    artifact = _decode_artifact(revoked_token)
+    token_id = artifact["payload"]["token_id"]
+    settings.license_revoked_jtis = frozenset({token_id})
     headers = [
         (b"x-api-key", b"test-secret"),
         (HEADER_NAME.lower().encode(), revoked_token.encode()),


### PR DESCRIPTION
## Summary
- update API middleware to verify licenses with the shared Ed25519 LicenseVerifier flow
- refactor license claim helpers to normalize LicensePayload objects and preserve trial behaviour
- refresh middleware tests to mint Ed25519 tokens with the CLI and cover revocation/expiry cases

## Testing
- pytest tests/test_middleware.py tests/test_license_validator.py *(fails: missing fastapi dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d5d188e88329826876b5a9fc473e