### PR TITLE
Add React Tailwind UI shell for invoice console

### DIFF
--- a/apps/ui/.eslintrc.cjs
+++ b/apps/ui/.eslintrc.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:react/jsx-runtime', 'prettier'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  rules: {
+    'react/prop-types': 'off'
+  }
+};

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -1,0 +1,47 @@
+# AI Invoice Console UI
+
+Minimalist dual-theme React + Tailwind dashboard for the AI Invoice platform. The UI ships with mocked data so it can be explored offline while providing a ready structure for wiring real APIs later.
+
+## Prerequisites
+
+- Node.js 18+
+- npm 9+
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+Then open `http://localhost:5173` in your browser.
+
+To create a production build:
+
+```bash
+npm run build
+```
+
+### Project structure
+
+```
+apps/ui
+├── package.json
+├── index.html
+├── src
+│   ├── App.tsx
+│   ├── components
+│   ├── data
+│   ├── hooks
+│   └── sections
+├── tailwind.config.js
+└── tsconfig.json
+```
+
+## Theming
+
+The UI uses Indigo `#3F51B5` as the primary color with Costa Rica accents (`#CE1126` and `#002B7F`) and supports light, dark, and system themes. Preferences persist via `localStorage` and automatically react to OS theme changes.
+
+## Mock data
+
+All dashboards, tables, and workflows use static mocks under `src/data/mockData.ts`. Swap these with live fetches (e.g., `/invoices`, `/vendors`, `/approvals`) once backend endpoints are ready.

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" class="h-full">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Invoice Console</title>
+  </head>
+  <body class="h-full bg-slate-100">
+    <div id="root" class="h-full"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "ai-invoice-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+  },
+  "dependencies": {
+    "clsx": "^2.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.34.0",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.0",
+    "vite": "^5.1.0"
+  }
+}

--- a/apps/ui/postcss.config.js
+++ b/apps/ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1,0 +1,98 @@
+import { useMemo, useState } from 'react';
+import { ThemeProvider } from './hooks/useTheme';
+import { Sidebar } from './components/Sidebar';
+import { TopBar } from './components/TopBar';
+import { DashboardSection } from './sections/DashboardSection';
+import { InvoiceViewerSection } from './sections/InvoiceViewerSection';
+import { VendorListSection } from './sections/VendorListSection';
+import { ReportsSection } from './sections/ReportsSection';
+import { ApprovalsSection } from './sections/ApprovalsSection';
+import { SettingsSection } from './sections/SettingsSection';
+
+export type AppSectionKey =
+  | 'dashboard'
+  | 'invoices'
+  | 'vendors'
+  | 'reports'
+  | 'approvals'
+  | 'settings';
+
+type SectionItem = {
+  id: AppSectionKey;
+  label: string;
+  description: string;
+  component: JSX.Element;
+};
+
+const useSections = (): SectionItem[] =>
+  useMemo(
+    () => [
+      {
+        id: 'dashboard',
+        label: 'Dashboard',
+        description: 'Pulse of your invoice operations at a glance.',
+        component: <DashboardSection />
+      },
+      {
+        id: 'invoices',
+        label: 'Invoice Viewer',
+        description: 'Details, line items, and actions for the current invoice.',
+        component: <InvoiceViewerSection />
+      },
+      {
+        id: 'vendors',
+        label: 'Vendors',
+        description: 'Searchable directory of suppliers with contact details.',
+        component: <VendorListSection />
+      },
+      {
+        id: 'reports',
+        label: 'Reports',
+        description: 'Download-ready summaries and insights for finance teams.',
+        component: <ReportsSection />
+      },
+      {
+        id: 'approvals',
+        label: 'Approvals',
+        description: 'Fast approval workflow with delightful micro-animations.',
+        component: <ApprovalsSection />
+      },
+      {
+        id: 'settings',
+        label: 'Settings',
+        description: 'Theme controls, notifications, and workspace preferences.',
+        component: <SettingsSection />
+      }
+    ],
+    []
+  );
+
+const AppShell = () => {
+  const sections = useSections();
+  const [active, setActive] = useState<AppSectionKey>('dashboard');
+  const current = sections.find((section) => section.id === active) ?? sections[0];
+
+  return (
+    <div className="flex h-full min-h-screen bg-slate-100 dark:bg-slate-950">
+      <Sidebar
+        sections={sections.map(({ id, label }) => ({ id, label }))}
+        active={active}
+        onSelect={setActive}
+      />
+      <div className="flex flex-1 flex-col">
+        <TopBar title={current.label} description={current.description} />
+        <main className="flex-1 overflow-y-auto px-6 pb-12 pt-6 sm:px-10">
+          <div className="mx-auto max-w-6xl space-y-8">{current.component}</div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+const App = () => (
+  <ThemeProvider>
+    <AppShell />
+  </ThemeProvider>
+);
+
+export default App;

--- a/apps/ui/src/components/Card.tsx
+++ b/apps/ui/src/components/Card.tsx
@@ -1,0 +1,31 @@
+import { clsx } from 'clsx';
+import { PropsWithChildren } from 'react';
+
+type CardProps = PropsWithChildren<{
+  title?: string;
+  eyebrow?: string;
+  actions?: React.ReactNode;
+  className?: string;
+}>;
+
+export const Card = ({ title, eyebrow, actions, children, className }: CardProps) => {
+  return (
+    <section
+      className={clsx(
+        'rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-card backdrop-blur dark:border-slate-800 dark:bg-slate-900/60',
+        className
+      )}
+    >
+      {(eyebrow || title || actions) && (
+        <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            {eyebrow && <p className="text-xs font-semibold uppercase tracking-wide text-indigoBrand">{eyebrow}</p>}
+            {title && <h2 className="mt-1 text-base font-semibold text-slate-800 dark:text-slate-100">{title}</h2>}
+          </div>
+          {actions}
+        </header>
+      )}
+      <div className="text-sm text-slate-600 dark:text-slate-300">{children}</div>
+    </section>
+  );
+};

--- a/apps/ui/src/components/Sidebar.tsx
+++ b/apps/ui/src/components/Sidebar.tsx
@@ -1,0 +1,122 @@
+import { AppSectionKey } from '../App';
+import { ThemeMode, useTheme } from '../hooks/useTheme';
+import { ThemeToggle } from './ThemeToggle';
+
+const navIcons: Record<AppSectionKey, JSX.Element> = {
+  dashboard: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path
+        d="M4 13h7V4H4v9zm0 7h7v-5H4v5zm9 0h7V11h-7v9zm0-16v5h7V4h-7z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+  invoices: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path
+        d="M7 4h10a2 2 0 0 1 2 2v13.5l-4-2-3 2-3-2-4 2V6a2 2 0 0 1 2-2zm2 4v2h6V8H9zm0 4v2h6v-2H9z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+  vendors: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path
+        d="M12 12a4 4 0 1 0-4-4 4 4 0 0 0 4 4zm0 2c-3.31 0-9 1.66-9 5v1h18v-1c0-3.34-5.69-5-9-5z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+  reports: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path
+        d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zm3 6v10h2V9H8zm4 4v6h2v-6h-2zm4-3v9h2V10h-2z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+  approvals: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path
+        d="M9 16.17 5.83 13l-1.42 1.41L9 19l12-12-1.41-1.41L9 16.17z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+  settings: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path
+        d="M19.14 12.94a7.14 7.14 0 0 0 0-1.88l2.03-1.58-1.92-3.32-2.39.95a7.15 7.15 0 0 0-1.62-.94l-.36-2.54h-3.84l-.36 2.54a7.15 7.15 0 0 0-1.62.94l-2.39-.95-1.92 3.32 2.03 1.58a7.14 7.14 0 0 0 0 1.88L3.53 14.5l1.92 3.32 2.39-.95c.5.38 1.05.69 1.62.94l.36 2.54h3.84l.36-2.54c.57-.25 1.12-.56 1.62-.94l2.39.95 1.92-3.32-2.03-1.56zM12 14.5a2.5 2.5 0 1 1 2.5-2.5A2.5 2.5 0 0 1 12 14.5z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+};
+
+type SidebarProps = {
+  sections: Array<{ id: AppSectionKey; label: string }>;
+  active: AppSectionKey;
+  onSelect: (id: AppSectionKey) => void;
+};
+
+export const Sidebar = ({ sections, active, onSelect }: SidebarProps) => {
+  const { mode, setMode } = useTheme();
+  const handleModeChange = (value: ThemeMode) => () => setMode(value);
+
+  return (
+    <aside className="hidden w-64 flex-col border-r border-slate-200 bg-white/80 p-4 backdrop-blur dark:border-slate-800 dark:bg-slate-900/60 lg:flex">
+      <div className="flex items-center gap-2 px-2 py-3 text-sm font-semibold tracking-wide text-slate-700 dark:text-slate-200">
+        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-indigoBrand/10 text-indigoBrand">
+          AI
+        </span>
+        <span>Invoice Console</span>
+      </div>
+      <nav className="mt-6 flex-1 space-y-1 text-sm">
+        {sections.map((section) => {
+          const isActive = section.id === active;
+          return (
+            <button
+              key={section.id}
+              onClick={() => onSelect(section.id)}
+              className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition ${
+                isActive
+                  ? 'bg-indigoBrand/10 font-semibold text-indigoBrand'
+                  : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800'
+              }`}
+            >
+              <span className={isActive ? 'text-indigoBrand' : 'text-slate-400'}>{navIcons[section.id]}</span>
+              <span>{section.label}</span>
+            </button>
+          );
+        })}
+      </nav>
+      <div className="mt-auto space-y-2 rounded-lg border border-slate-200 p-3 dark:border-slate-800">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Theme
+        </p>
+        <div className="flex gap-2">
+          {(
+            [
+              { id: 'light', label: 'Light' },
+              { id: 'system', label: 'Auto' },
+              { id: 'dark', label: 'Dark' }
+            ] as Array<{ id: ThemeMode; label: string }>
+          ).map((option) => (
+            <button
+              key={option.id}
+              onClick={handleModeChange(option.id)}
+              className={`flex-1 rounded-md border px-2 py-1 text-xs font-medium transition ${
+                mode === option.id
+                  ? 'border-indigoBrand bg-indigoBrand/10 text-indigoBrand'
+                  : 'border-slate-200 text-slate-500 hover:border-slate-300 dark:border-slate-700 dark:text-slate-300'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+        <ThemeToggle className="w-full" />
+      </div>
+    </aside>
+  );
+};

--- a/apps/ui/src/components/ThemeToggle.tsx
+++ b/apps/ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,38 @@
+import { clsx } from 'clsx';
+import { useTheme } from '../hooks/useTheme';
+
+type ThemeToggleProps = {
+  className?: string;
+};
+
+export const ThemeToggle = ({ className }: ThemeToggleProps) => {
+  const { mode, setMode } = useTheme();
+  const order: Array<'light' | 'dark' | 'system'> = ['light', 'dark', 'system'];
+  const nextMode = order[(order.indexOf(mode) + 1) % order.length];
+  const labelMap: Record<typeof order[number], string> = {
+    light: 'Light mode',
+    dark: 'Dark mode',
+    system: 'Match system'
+  };
+
+  return (
+    <button
+      onClick={() => setMode(nextMode)}
+      className={clsx(
+        'inline-flex items-center justify-center gap-2 rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition hover:border-indigoBrand hover:text-indigoBrand dark:border-slate-700 dark:text-slate-300 dark:hover:border-indigoBrand dark:hover:text-indigoBrand',
+        className
+      )}
+    >
+      <span className="flex h-5 w-5 items-center justify-center">
+        {mode === 'dark' ? (
+          <span aria-hidden className="text-base">🌙</span>
+        ) : mode === 'light' ? (
+          <span aria-hidden className="text-base">☀️</span>
+        ) : (
+          <span aria-hidden className="text-base">🌓</span>
+        )}
+      </span>
+      <span className="text-xs uppercase tracking-wide">{labelMap[mode]}</span>
+    </button>
+  );
+};

--- a/apps/ui/src/components/TopBar.tsx
+++ b/apps/ui/src/components/TopBar.tsx
@@ -1,0 +1,23 @@
+import { ThemeToggle } from './ThemeToggle';
+
+type TopBarProps = {
+  title: string;
+  description: string;
+};
+
+export const TopBar = ({ title, description }: TopBarProps) => {
+  return (
+    <header className="border-b border-slate-200 bg-white/70 backdrop-blur dark:border-slate-800 dark:bg-slate-900/60">
+      <div className="h-1 w-full bg-gradient-to-r from-crBlue via-white to-crRed" aria-hidden></div>
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5 sm:px-10">
+        <div>
+          <h1 className="text-lg font-semibold text-slate-800 dark:text-slate-100">{title}</h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{description}</p>
+        </div>
+        <div className="hidden sm:block">
+          <ThemeToggle />
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/apps/ui/src/data/mockData.ts
+++ b/apps/ui/src/data/mockData.ts
@@ -1,0 +1,189 @@
+export const kpiCards = [
+  {
+    label: 'Pending Approvals',
+    value: 8,
+    delta: '+2 vs last week',
+    trend: 'up'
+  },
+  {
+    label: 'Invoices Processed',
+    value: 142,
+    delta: '+12% efficiency',
+    trend: 'up'
+  },
+  {
+    label: 'Average Cycle Time',
+    value: '2.4d',
+    delta: '-0.6d this month',
+    trend: 'down'
+  },
+  {
+    label: 'Exceptions',
+    value: 3,
+    delta: '2 high priority',
+    trend: 'neutral'
+  }
+];
+
+export const cashFlowSeries = [
+  { day: 'Mon', value: 12 },
+  { day: 'Tue', value: 18 },
+  { day: 'Wed', value: 15 },
+  { day: 'Thu', value: 22 },
+  { day: 'Fri', value: 26 },
+  { day: 'Sat', value: 21 },
+  { day: 'Sun', value: 24 }
+];
+
+export const invoiceSummary = {
+  id: 'INV-2098',
+  vendor: 'Pura Vida Supplies',
+  issuedOn: '2025-05-02',
+  dueOn: '2025-05-16',
+  amount: '$4,860.00',
+  status: 'Awaiting Approval',
+  reference: 'PO-6635',
+  notes: 'Expedited shipping requested'
+};
+
+export const invoiceLineItems = [
+  {
+    id: '1',
+    description: 'Thermal paper rolls',
+    quantity: 120,
+    unitCost: '$12.50',
+    amount: '$1,500.00'
+  },
+  {
+    id: '2',
+    description: 'Receipt printers',
+    quantity: 15,
+    unitCost: '$120.00',
+    amount: '$1,800.00'
+  },
+  {
+    id: '3',
+    description: 'POS tablets (Wi-Fi)',
+    quantity: 6,
+    unitCost: '$220.00',
+    amount: '$1,320.00'
+  },
+  {
+    id: '4',
+    description: 'Custom cabling kit',
+    quantity: 6,
+    unitCost: '$40.00',
+    amount: '$240.00'
+  }
+];
+
+export const vendors = [
+  {
+    id: 'v-01',
+    name: 'Pura Vida Supplies',
+    category: 'Hardware',
+    contact: 'andrea@puravida.cr',
+    status: 'Active'
+  },
+  {
+    id: 'v-02',
+    name: 'San José Stationers',
+    category: 'Office Supplies',
+    contact: 'ventas@sanjose.co.cr',
+    status: 'Active'
+  },
+  {
+    id: 'v-03',
+    name: 'CloudCafe Roasters',
+    category: 'Hospitality',
+    contact: 'orders@cloudcafe.cr',
+    status: 'On Hold'
+  },
+  {
+    id: 'v-04',
+    name: 'Montezuma Analytics',
+    category: 'Consulting',
+    contact: 'sofia@montezuma.io',
+    status: 'Active'
+  },
+  {
+    id: 'v-05',
+    name: 'Tamarindo Creative',
+    category: 'Design',
+    contact: 'hola@tamarindocreative.cr',
+    status: 'Prospect'
+  }
+];
+
+export const reports = [
+  {
+    id: 'r-01',
+    title: 'Monthly Spend Overview',
+    description: 'Summary of paid vs outstanding invoices by department.',
+    updated: 'Updated 2 days ago'
+  },
+  {
+    id: 'r-02',
+    title: 'Aging Report',
+    description: 'Breakdown of invoices by 0-30, 31-60, 61-90, and 90+ days.',
+    updated: 'Updated yesterday'
+  },
+  {
+    id: 'r-03',
+    title: 'Vendor Performance',
+    description: 'Delivery, accuracy, and SLA insights by supplier.',
+    updated: 'Updated 4 days ago'
+  }
+];
+
+export const approvals = [
+  {
+    id: 'a-01',
+    title: 'Invoice INV-2098',
+    vendor: 'Pura Vida Supplies',
+    amount: '$4,860.00',
+    submitted: '2h ago',
+    status: 'Pending'
+  },
+  {
+    id: 'a-02',
+    title: 'Purchase Request PR-447',
+    vendor: 'CloudCafe Roasters',
+    amount: '$980.00',
+    submitted: '5h ago',
+    status: 'Pending'
+  },
+  {
+    id: 'a-03',
+    title: 'Contract Renewal CT-032',
+    vendor: 'Montezuma Analytics',
+    amount: '$12,400.00',
+    submitted: 'Yesterday',
+    status: 'Pending'
+  }
+];
+
+export const settingToggles = [
+  {
+    id: 'notifications',
+    label: 'Email me daily approval summaries',
+    description: 'Receive a short digest every morning at 8:00 am.'
+  },
+  {
+    id: 'autoAssign',
+    label: 'Auto-assign invoices under $1,000',
+    description: 'Automatically route small invoices to fast-track queue.'
+  },
+  {
+    id: 'reminders',
+    label: 'Enable due date reminders',
+    description: 'Send heads-up notifications 3 days before an invoice is due.'
+  }
+];
+
+export const accentSwatches = [
+  { id: 'indigo', label: 'Indigo Core', value: '#3F51B5' },
+  { id: 'flagBlue', label: 'Catalina Blue', value: '#002B7F' },
+  { id: 'flagRed', label: 'Philippine Red', value: '#CE1126' },
+  { id: 'rainforest', label: 'Rainforest Green', value: '#3C8D0D' }
+];

--- a/apps/ui/src/hooks/useTheme.tsx
+++ b/apps/ui/src/hooks/useTheme.tsx
@@ -1,0 +1,92 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+type ThemeMode = 'light' | 'dark' | 'system';
+
+type ThemeContextValue = {
+  mode: ThemeMode;
+  effectiveTheme: 'light' | 'dark';
+  setMode: (mode: ThemeMode) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'ai-invoice-theme';
+
+const getPreferredColorScheme = () => {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return 'light';
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+const applyTheme = (mode: ThemeMode) => {
+  const resolved = mode === 'system' ? getPreferredColorScheme() : mode;
+  const root = window.document.documentElement;
+  root.dataset.theme = resolved;
+  if (resolved === 'dark') {
+    root.classList.add('dark');
+  } else {
+    root.classList.remove('dark');
+  }
+  return resolved;
+};
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [mode, setMode] = useState<ThemeMode>(() => {
+    if (typeof window === 'undefined') {
+      return 'light';
+    }
+    return (window.localStorage.getItem(STORAGE_KEY) as ThemeMode) || 'system';
+  });
+  const [effectiveTheme, setEffectiveTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window === 'undefined') {
+      return 'light';
+    }
+    const stored = (window.localStorage.getItem(STORAGE_KEY) as ThemeMode) || 'system';
+    return stored === 'system' ? getPreferredColorScheme() : stored;
+  });
+
+  useEffect(() => {
+    const resolved = applyTheme(mode);
+    setEffectiveTheme(resolved);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, mode);
+    }
+  }, [mode]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => {
+      if (mode === 'system') {
+        const resolved = applyTheme('system');
+        setEffectiveTheme(resolved);
+      }
+    };
+    media.addEventListener('change', handler);
+    return () => media.removeEventListener('change', handler);
+  }, [mode]);
+
+  const value = useMemo(
+    () => ({
+      mode,
+      setMode,
+      effectiveTheme
+    }),
+    [mode, effectiveTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return ctx;
+};
+
+export type { ThemeMode };

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -1,0 +1,36 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  @apply bg-slate-100 text-slate-900 antialiased;
+}
+
+.dark body {
+  @apply bg-slate-900 text-slate-100;
+}
+
+::-webkit-scrollbar {
+  width: 0.6rem;
+}
+
+::-webkit-scrollbar-thumb {
+  @apply bg-slate-400/60 rounded-full;
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  @apply bg-slate-700 rounded-full;
+}

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/ui/src/sections/ApprovalsSection.tsx
+++ b/apps/ui/src/sections/ApprovalsSection.tsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from 'react';
+import { Card } from '../components/Card';
+import { approvals as approvalQueue } from '../data/mockData';
+
+type ApprovalState = 'Pending' | 'Approved' | 'Rejected';
+
+type ApprovalItem = {
+  id: string;
+  title: string;
+  vendor: string;
+  amount: string;
+  submitted: string;
+  status: ApprovalState;
+};
+
+export const ApprovalsSection = () => {
+  const initial = useMemo<ApprovalItem[]>(
+    () => approvalQueue.map((item) => ({ ...item })),
+    []
+  );
+  const [items, setItems] = useState(initial);
+  const [feedback, setFeedback] = useState<{ message: string; tone: 'approve' | 'reject' } | null>(null);
+
+  const handleAction = (id: string, status: ApprovalState) => {
+    setItems((prev) => prev.map((item) => (item.id === id ? { ...item, status } : item)));
+    setFeedback({
+      message: status === 'Approved' ? 'Invoice approved and routed to ERP ✅' : 'Invoice rejected with feedback 📨',
+      tone: status === 'Approved' ? 'approve' : 'reject'
+    });
+    setTimeout(() => setFeedback(null), 2600);
+  };
+
+  const pending = items.filter((item) => item.status === 'Pending');
+  const completed = items.filter((item) => item.status !== 'Pending');
+
+  return (
+    <div className="space-y-6">
+      {feedback && (
+        <div
+          className={`rounded-xl border px-4 py-3 text-sm shadow-card transition ${
+            feedback.tone === 'approve'
+              ? 'border-crGreen/40 bg-crGreen/10 text-crGreen animate-approve'
+              : 'border-crRed/40 bg-crRed/10 text-crRed animate-reject'
+          }`}
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      <Card title="Pending approvals" eyebrow="Action needed">
+        <div className="space-y-3">
+          {pending.map((item) => (
+            <div
+              key={item.id}
+              className="flex flex-col gap-3 rounded-2xl border border-slate-200/80 bg-white/70 p-4 transition hover:border-indigoBrand/60 dark:border-slate-800/80 dark:bg-slate-900/40 md:flex-row md:items-center md:justify-between"
+            >
+              <div>
+                <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">{item.title}</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  {item.vendor} • {item.amount} • {item.submitted}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => handleAction(item.id, 'Approved')}
+                  className="inline-flex items-center gap-2 rounded-full bg-indigoBrand px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:shadow"
+                >
+                  <span aria-hidden>✓</span> Approve
+                </button>
+                <button
+                  onClick={() => handleAction(item.id, 'Rejected')}
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold text-slate-500 transition hover:border-crRed hover:text-crRed"
+                >
+                  <span aria-hidden>✕</span> Reject
+                </button>
+              </div>
+            </div>
+          ))}
+          {pending.length === 0 && (
+            <div className="rounded-xl border border-slate-200/70 bg-white/40 p-6 text-sm text-slate-500 dark:border-slate-800/60 dark:bg-slate-900/30">
+              Nothing left to review — enjoy your cafecito ☕️
+            </div>
+          )}
+        </div>
+      </Card>
+
+      <Card title="History" eyebrow="Recent decisions">
+        <div className="space-y-3 text-sm">
+          {completed.map((item) => (
+            <div
+              key={item.id}
+              className={`flex items-center justify-between rounded-xl border px-4 py-3 ${
+                item.status === 'Approved'
+                  ? 'border-crGreen/40 bg-crGreen/5 text-crGreen'
+                  : 'border-crRed/40 bg-crRed/5 text-crRed'
+              }`}
+            >
+              <div>
+                <p className="font-semibold">{item.title}</p>
+                <p className="text-xs opacity-80">
+                  {item.vendor} • {item.amount}
+                </p>
+              </div>
+              <span className="text-xs font-bold uppercase tracking-wide">{item.status}</span>
+            </div>
+          ))}
+          {completed.length === 0 && (
+            <p className="text-xs text-slate-400">No decisions yet.</p>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+};

--- a/apps/ui/src/sections/DashboardSection.tsx
+++ b/apps/ui/src/sections/DashboardSection.tsx
@@ -1,0 +1,96 @@
+import { kpiCards, cashFlowSeries } from '../data/mockData';
+import { Card } from '../components/Card';
+
+const buildSparkPath = (values: number[], width: number, height: number) => {
+  if (values.length === 0) {
+    return '';
+  }
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const stepX = width / (values.length - 1 || 1);
+  return values
+    .map((value, index) => {
+      const normalized = max === min ? 0.5 : (value - min) / (max - min);
+      const x = index * stepX;
+      const y = height - normalized * height;
+      return `${index === 0 ? 'M' : 'L'}${x},${y}`;
+    })
+    .join(' ');
+};
+
+export const DashboardSection = () => {
+  const values = cashFlowSeries.map((point) => point.value);
+  const path = buildSparkPath(values, 220, 80);
+
+  return (
+    <div className="space-y-8">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {kpiCards.map((card) => (
+          <Card key={card.label} className="relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-br from-indigoBrand/5 via-transparent to-crBlue/5" aria-hidden></div>
+            <div className="relative flex flex-col gap-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                {card.label}
+              </p>
+              <span className="text-2xl font-semibold text-slate-900 dark:text-white">{card.value}</span>
+              <span
+                className={`text-xs font-medium ${
+                  card.trend === 'up'
+                    ? 'text-crGreen'
+                    : card.trend === 'down'
+                    ? 'text-crRed'
+                    : 'text-slate-500'
+                }`}
+              >
+                {card.delta}
+              </span>
+            </div>
+          </Card>
+        ))}
+      </div>
+
+      <Card title="Cash Flow Trend" eyebrow="This week" className="overflow-hidden">
+        <div className="grid gap-6 lg:grid-cols-[220px,1fr]">
+          <div>
+            <svg viewBox="0 0 220 80" className="h-24 w-full text-indigoBrand" aria-hidden>
+              <path d={path} fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+              {cashFlowSeries.map((point, index) => {
+                const max = Math.max(...values);
+                const min = Math.min(...values);
+                const stepX = 220 / (values.length - 1 || 1);
+                const normalized = max === min ? 0.5 : (point.value - min) / (max - min);
+                const x = index * stepX;
+                const y = 80 - normalized * 80;
+                return <circle key={point.day} cx={x} cy={y} r={3} className="fill-indigoBrand" />;
+              })}
+            </svg>
+            <div className="flex justify-between text-xs text-slate-500 dark:text-slate-400">
+              {cashFlowSeries.map((point) => (
+                <span key={point.day}>{point.day}</span>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-4">
+            <div className="rounded-xl border border-slate-200/70 bg-white/40 p-4 text-sm dark:border-slate-800/70 dark:bg-slate-900/40">
+              <p className="font-semibold text-slate-700 dark:text-slate-200">Today</p>
+              <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">₡13.6M collected</p>
+              <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                Collections are trending 8% above average with fewer late payments from strategic vendors.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="rounded-xl border border-slate-200/70 p-4 dark:border-slate-800/70">
+                <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Fast track queue</p>
+                <p className="mt-1 text-xl font-semibold text-slate-900 dark:text-white">14 invoices</p>
+              </div>
+              <div className="rounded-xl border border-slate-200/70 p-4 dark:border-slate-800/70">
+                <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Avg approval time</p>
+                <p className="mt-1 text-xl font-semibold text-slate-900 dark:text-white">5h 12m</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+};

--- a/apps/ui/src/sections/InvoiceViewerSection.tsx
+++ b/apps/ui/src/sections/InvoiceViewerSection.tsx
@@ -1,0 +1,81 @@
+import { Card } from '../components/Card';
+import { invoiceLineItems, invoiceSummary } from '../data/mockData';
+
+export const InvoiceViewerSection = () => {
+  return (
+    <div className="space-y-6">
+      <Card title="Invoice Summary" eyebrow="INV-2098" actions={<InvoiceActions />}>
+        <dl className="grid gap-4 sm:grid-cols-2">
+          <Item label="Vendor" value={invoiceSummary.vendor} />
+          <Item label="Status" value={invoiceSummary.status} accent="bg-amber-100 text-amber-700" />
+          <Item label="Issued" value={invoiceSummary.issuedOn} />
+          <Item label="Due" value={invoiceSummary.dueOn} />
+          <Item label="Total" value={invoiceSummary.amount} emphasis />
+          <Item label="Reference" value={invoiceSummary.reference} />
+          <div className="sm:col-span-2">
+            <Item label="Notes" value={invoiceSummary.notes} />
+          </div>
+        </dl>
+      </Card>
+
+      <Card title="Line items" eyebrow="Breakdown">
+        <div className="overflow-hidden rounded-xl border border-slate-200/70 dark:border-slate-800/70">
+          <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+            <thead className="bg-slate-50/70 text-left text-xs uppercase tracking-wide text-slate-500 dark:bg-slate-800/40 dark:text-slate-400">
+              <tr>
+                <th className="px-4 py-3">Description</th>
+                <th className="px-4 py-3">Qty</th>
+                <th className="px-4 py-3">Unit Cost</th>
+                <th className="px-4 py-3 text-right">Amount</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 text-sm dark:divide-slate-800">
+              {invoiceLineItems.map((item, index) => (
+                <tr
+                  key={item.id}
+                  className={index % 2 === 0 ? 'bg-white/70 dark:bg-slate-900/40' : 'bg-slate-50/50 dark:bg-slate-900/20'}
+                >
+                  <td className="px-4 py-3 font-medium text-slate-700 dark:text-slate-200">{item.description}</td>
+                  <td className="px-4 py-3 text-slate-500 dark:text-slate-400">{item.quantity}</td>
+                  <td className="px-4 py-3 text-slate-500 dark:text-slate-400">{item.unitCost}</td>
+                  <td className="px-4 py-3 text-right font-semibold text-slate-700 dark:text-slate-200">{item.amount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+type ItemProps = {
+  label: string;
+  value: string;
+  emphasis?: boolean;
+  accent?: string;
+};
+
+const Item = ({ label, value, emphasis, accent }: ItemProps) => (
+  <div>
+    <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</dt>
+    <dd
+      className={`mt-1 text-base ${
+        accent ? accent : emphasis ? 'font-semibold text-slate-900 dark:text-white' : 'text-slate-700 dark:text-slate-200'
+      }`}
+    >
+      {value}
+    </dd>
+  </div>
+);
+
+const InvoiceActions = () => (
+  <div className="flex gap-2">
+    <button className="rounded-full border border-indigoBrand px-4 py-2 text-xs font-semibold text-indigoBrand transition hover:bg-indigoBrand hover:text-white">
+      Approve
+    </button>
+    <button className="rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold text-slate-500 transition hover:border-crRed hover:text-crRed">
+      Reject
+    </button>
+  </div>
+);

--- a/apps/ui/src/sections/ReportsSection.tsx
+++ b/apps/ui/src/sections/ReportsSection.tsx
@@ -1,0 +1,21 @@
+import { Card } from '../components/Card';
+import { reports } from '../data/mockData';
+
+export const ReportsSection = () => {
+  return (
+    <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+      {reports.map((report) => (
+        <Card key={report.id} title={report.title} eyebrow="Report">
+          <p>{report.description}</p>
+          <div className="mt-6 flex items-center justify-between text-xs text-slate-400 dark:text-slate-500">
+            <span>{report.updated}</span>
+            <button className="inline-flex items-center gap-2 rounded-full border border-indigoBrand px-4 py-2 font-semibold text-indigoBrand transition hover:bg-indigoBrand hover:text-white">
+              <span aria-hidden>⬇️</span>
+              Download
+            </button>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+};

--- a/apps/ui/src/sections/SettingsSection.tsx
+++ b/apps/ui/src/sections/SettingsSection.tsx
@@ -1,0 +1,73 @@
+import { Card } from '../components/Card';
+import { ThemeMode, useTheme } from '../hooks/useTheme';
+import { accentSwatches, settingToggles } from '../data/mockData';
+
+export const SettingsSection = () => {
+  const { mode, setMode, effectiveTheme } = useTheme();
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card title="Appearance" eyebrow="Personalize">
+        <p className="text-sm">
+          Choose between light, dark, or match the system setting. Preferences persist across sessions.
+        </p>
+        <div className="mt-4 flex gap-3">
+          {(
+            [
+              { id: 'light', label: 'Light' },
+              { id: 'system', label: 'Auto' },
+              { id: 'dark', label: 'Dark' }
+            ] as Array<{ id: ThemeMode; label: string }>
+          ).map((option) => (
+            <button
+              key={option.id}
+              onClick={() => setMode(option.id)}
+              className={`flex-1 rounded-2xl border px-4 py-3 text-sm font-semibold transition ${
+                mode === option.id
+                  ? 'border-indigoBrand bg-indigoBrand/10 text-indigoBrand'
+                  : 'border-slate-200 text-slate-500 hover:border-indigoBrand/40 dark:border-slate-700 dark:text-slate-300'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+        <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">
+          Currently displaying in <span className="font-semibold text-indigoBrand">{effectiveTheme}</span> theme.
+        </p>
+      </Card>
+
+      <Card title="Notification rules" eyebrow="Automation">
+        <div className="space-y-4">
+          {settingToggles.map((toggle) => (
+            <label
+              key={toggle.id}
+              className="flex cursor-pointer items-start gap-3 rounded-2xl border border-slate-200/80 bg-white/70 p-4 transition hover:border-indigoBrand/60 dark:border-slate-800/80 dark:bg-slate-900/40"
+            >
+              <input type="checkbox" defaultChecked className="mt-1 h-4 w-4 rounded border-slate-300 text-indigoBrand focus:ring-indigoBrand" />
+              <div>
+                <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">{toggle.label}</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">{toggle.description}</p>
+              </div>
+            </label>
+          ))}
+        </div>
+      </Card>
+
+      <Card title="Accent palette" eyebrow="Costa Rica inspired" className="lg:col-span-2">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {accentSwatches.map((swatch) => (
+            <div
+              key={swatch.id}
+              className="flex flex-col items-center gap-3 rounded-2xl border border-slate-200/80 bg-white/70 p-4 dark:border-slate-800/80 dark:bg-slate-900/40"
+            >
+              <span className="h-16 w-16 rounded-full shadow-inner" style={{ backgroundColor: swatch.value }} aria-hidden></span>
+              <div className="text-center text-sm font-semibold text-slate-700 dark:text-slate-200">{swatch.label}</div>
+              <div className="text-xs text-slate-500 dark:text-slate-400">{swatch.value}</div>
+            </div>
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+};

--- a/apps/ui/src/sections/VendorListSection.tsx
+++ b/apps/ui/src/sections/VendorListSection.tsx
@@ -1,0 +1,69 @@
+import { useMemo, useState } from 'react';
+import { Card } from '../components/Card';
+import { vendors } from '../data/mockData';
+
+export const VendorListSection = () => {
+  const [query, setQuery] = useState('');
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) {
+      return vendors;
+    }
+    return vendors.filter((vendor) =>
+      [vendor.name, vendor.category, vendor.contact, vendor.status].some((field) =>
+        field.toLowerCase().includes(normalized)
+      )
+    );
+  }, [query]);
+
+  return (
+    <Card title="Vendor directory" eyebrow="Suppliers">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="relative w-full sm:w-72">
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search vendors…"
+            className="w-full rounded-full border border-slate-300 bg-white/80 px-4 py-2 text-sm text-slate-600 placeholder:text-slate-400 shadow-sm transition focus:border-indigoBrand focus:outline-none focus:ring-2 focus:ring-indigoBrand/20 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200"
+          />
+          <span className="pointer-events-none absolute inset-y-0 right-4 flex items-center text-slate-400">⌕</span>
+        </div>
+        <p className="text-xs text-slate-400 dark:text-slate-500">
+          Showing <span className="font-semibold text-indigoBrand">{filtered.length}</span> of {vendors.length} vendors
+        </p>
+      </div>
+      <div className="overflow-hidden rounded-xl border border-slate-200/70 dark:border-slate-800/70">
+        <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+          <thead className="bg-slate-50/70 text-left text-xs uppercase tracking-wide text-slate-500 dark:bg-slate-800/40 dark:text-slate-400">
+            <tr>
+              <th className="px-4 py-3">Vendor</th>
+              <th className="px-4 py-3">Category</th>
+              <th className="px-4 py-3">Contact</th>
+              <th className="px-4 py-3">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 text-sm dark:divide-slate-800">
+            {filtered.map((vendor, index) => (
+              <tr
+                key={vendor.id}
+                className={index % 2 === 0 ? 'bg-white/70 dark:bg-slate-900/40' : 'bg-slate-50/40 dark:bg-slate-900/30'}
+              >
+                <td className="px-4 py-3 font-medium text-slate-700 dark:text-slate-200">{vendor.name}</td>
+                <td className="px-4 py-3 text-slate-500 dark:text-slate-400">{vendor.category}</td>
+                <td className="px-4 py-3 text-slate-500 dark:text-slate-400">{vendor.contact}</td>
+                <td className="px-4 py-3">
+                  <span className="inline-flex items-center rounded-full bg-indigoBrand/10 px-3 py-1 text-xs font-semibold text-indigoBrand">
+                    {vendor.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {filtered.length === 0 && (
+          <div className="p-6 text-center text-sm text-slate-500 dark:text-slate-400">No vendors match your search.</div>
+        )}
+      </div>
+    </Card>
+  );
+};

--- a/apps/ui/tailwind.config.js
+++ b/apps/ui/tailwind.config.js
@@ -1,0 +1,35 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        indigoBrand: '#3F51B5',
+        crRed: '#CE1126',
+        crBlue: '#002B7F',
+        crGreen: '#3C8D0D'
+      },
+      boxShadow: {
+        card: '0 10px 25px -20px rgba(0, 0, 0, 0.45)'
+      },
+      keyframes: {
+        approve: {
+          '0%': { transform: 'scale(0.9)', opacity: '0' },
+          '60%': { transform: 'scale(1.05)', opacity: '1' },
+          '100%': { transform: 'scale(1)', opacity: '1' }
+        },
+        reject: {
+          '0%': { transform: 'translateX(0)' },
+          '50%': { transform: 'translateX(-6px)' },
+          '100%': { transform: 'translateX(0)' }
+        }
+      },
+      animation: {
+        approve: 'approve 320ms ease-out',
+        reject: 'reject 260ms ease-out'
+      }
+    }
+  },
+  plugins: []
+};

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/ui/tsconfig.node.json
+++ b/apps/ui/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});

--- a/docs/minimalist_dual_theme_app_ui.md
+++ b/docs/minimalist_dual_theme_app_ui.md
@@ -1,0 +1,56 @@
+# Minimalist Dual-Theme App UI with Indigo & Costa Rica Accents
+
+## Introduction
+This proposal outlines a minimalist user interface for an invoice-centric management application that includes Dashboard, Invoice Viewer, Vendor List, Settings, Reports, and Approval Workflow sections. The design emphasizes simplicity, usability, and support for both Light and Dark themes while highlighting an Indigo-driven brand system accented with colors inspired by Costa Rica’s natural palette and national flag.
+
+## Core Sections & Layout
+
+### Dashboard
+- Present high-priority KPIs (pending invoices, upcoming due dates, approval counts) using modular cards aligned to a responsive grid.
+- Use concise typography and minimalist charts (bar/line) with soft grid lines; accentuate alerts with subtle flag-red highlights.
+- Enable drill-down navigation from each card to detailed views while retaining generous whitespace for clarity.
+
+### Invoice Viewer
+- Split layout into a summary panel (invoice ID, vendor, dates, totals, status) and detailed line items.
+- Employ a clean table with light dividers or alternating row shading, grouping secondary information into collapsible sections.
+- Anchor primary actions (Approve, Reject, Next/Previous) in a persistent bar that uses Indigo for the main CTA.
+
+### Vendor List
+- Provide a lightweight, searchable table of vendors (Name, Company, Contact, Status) with zebra striping or subtle dividers.
+- Surface row-level actions (edit, archive) on hover via simple line icons; highlight the active row with a muted Indigo tint.
+
+### Settings
+- Organize options into clear groupings (Profile, Preferences, Notifications, Theme) rendered as cards or segmented lists with ample padding.
+- Style toggles, checkboxes, and dropdowns with Indigo active states; expose the Light/Dark/Auto theme switch prominently.
+
+### Reports
+- Offer a list or grid of report cards summarizing title, timeframe, and available actions (view, download).
+- When displaying analytics, reuse minimalist table styling and restrained charts that emphasize hierarchy through typography and spacing.
+
+### Approval Workflow
+- Present an inbox of pending approvals via concise cards or rows showing key invoice metadata and status chips.
+- Use color coding carefully: Indigo for neutral actions, a soft green for approved states, and Costa Rica flag red for critical or rejected items.
+- Mirror the Invoice Viewer layout in the detailed approval screen with clear CTA buttons and optional comment fields.
+
+## Design Style & Principles
+- **Focus on essentials:** Only display elements that support the primary task; avoid decorative graphics that do not aid comprehension.
+- **Visual hierarchy:** Guide attention through consistent typographic scale, spacing, and grouping so users can scan effortlessly.
+- **Generous whitespace:** Maintain comfortable margins and padding to reinforce the minimalist aesthetic and touch-friendly targets.
+- **Flat aesthetics:** Favor flat components with occasional subtle shadows to establish depth without clutter.
+- **Typography & iconography:** Use a single sans-serif family with defined weights for headings/body text; pair with a cohesive set of flat line icons accompanied by labels for clarity.
+
+## Dual Light & Dark Mode Strategy
+- **Light mode:** Utilize off-white or light neutral backgrounds with dark gray text; apply Indigo to interactive elements and employ gentle shadows for elevation.
+- **Dark mode:** Adopt deep charcoal surfaces (#121212 range) with near-white text (#E0E0E0) and adjust Indigo saturation for legibility; lighten divider tones to preserve contrast.
+- **Accent handling:** Calibrate accent colors for each theme (slightly softened reds/greens in dark mode) to avoid glare while maintaining brand cues.
+- **Theme consistency:** Keep layout, iconography, and typography identical across modes; offer a toggle in Settings plus an Auto option that follows system preference.
+
+## Color Scheme & Branding
+- **Primary color:** Indigo (aligned with Costa Rica’s Catalina Blue) drives navigation highlights, primary buttons, and focus states.
+- **Neutrals:** Off-whites and soft grays (light mode) plus charcoal tones (dark mode) form ~60% of the palette to sustain minimalism.
+- **Accents:** Costa Rica flag red (#CE1126) provides ~10% accent for alerts, destructive actions, and badges; a muted tropical green supports success states and references the natural landscape.
+- **Distribution:** Follow the 60-30-10 rule—neutrals (60%), Indigo and related hues (30%), accents (10%)—to maintain visual balance.
+- **Guidelines:** Document explicit usage (e.g., Indigo = primary action, red = destructive, green = success) and ensure all color combinations meet WCAG contrast ratios.
+
+## Conclusion
+The minimalist dual-theme UI delivers a cohesive, culturally resonant experience that prioritizes clarity and efficiency. Users can swiftly interpret key metrics, inspect invoices, manage vendors, adjust settings, analyze reports, and process approvals without distraction. Consistent patterns, disciplined color usage, and synchronized Light/Dark themes ensure the interface remains intuitive while celebrating the app’s Indigo identity and Costa Rican roots.


### PR DESCRIPTION
## Summary
- scaffold a new React + Tailwind workspace under `apps/ui` with Vite tooling and linting
- implement the sidebar/top bar layout, theme provider, and mocked data powering dashboard, invoice, vendor, report, approval, and settings views
- document local setup and color defaults for the minimalist dual-theme UI

## Testing
- npm install *(fails: registry access blocked in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6de734730832990193fdd65cfd81b