### PR TITLE
Handle whitespace API base URLs

### DIFF
--- a/apps/ui/src/lib/api.test.ts
+++ b/apps/ui/src/lib/api.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildUrl } from './api';
+
+const env = import.meta.env as { VITE_API_BASE_URL?: string };
+const originalBase = env.VITE_API_BASE_URL;
+
+afterEach(() => {
+  if (originalBase === undefined) {
+    delete env.VITE_API_BASE_URL;
+  } else {
+    env.VITE_API_BASE_URL = originalBase;
+  }
+});
+
+describe('buildUrl', () => {
+  it('normalises whitespace around base and path while avoiding duplicate slashes', () => {
+    env.VITE_API_BASE_URL = ' https://api.example.com/v1/ ';
+
+    expect(buildUrl('  /invoices  ')).toBe('https://api.example.com/v1/invoices');
+  });
+
+  it('falls back to a relative path when the base URL is whitespace', () => {
+    env.VITE_API_BASE_URL = '   ';
+
+    expect(buildUrl(' invoices ')).toBe('/invoices');
+  });
+
+  it('uses relative paths when no base URL is set', () => {
+    delete env.VITE_API_BASE_URL;
+
+    expect(buildUrl('workspace/items')).toBe('/workspace/items');
+    expect(buildUrl('   /workspace/items  ')).toBe('/workspace/items');
+  });
+});

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -61,14 +61,24 @@ export const normaliseErrorDetail = (detail: unknown): string => {
   return String(detail);
 };
 
-const buildUrl = (path: string): string => {
-  const base = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '';
+export const buildUrl = (path: string): string => {
+  const rawBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '';
+  const base = rawBase.trim();
+  const trimmedPath = path.trim();
+
   if (!base) {
-    return path.startsWith('/') ? path : `/${path}`;
+    if (!trimmedPath) return '/';
+    return trimmedPath.startsWith('/') ? trimmedPath : `/${trimmedPath}`;
   }
-  const trimmedBase = base.endsWith('/') ? base.slice(0, -1) : base;
-  const trimmedPath = path.startsWith('/') ? path.slice(1) : path;
-  return `${trimmedBase}/${trimmedPath}`;
+
+  const normalisedBase = base.replace(/\/+$/, '');
+  const normalisedPath = trimmedPath.replace(/^\/+/, '');
+
+  if (!normalisedPath) {
+    return normalisedBase;
+  }
+
+  return `${normalisedBase}/${normalisedPath}`;
 };
 
 type RequestOptions = {


### PR DESCRIPTION
## Summary
- normalise the API base URL and request paths to avoid duplicate slashes
- fall back to relative URLs when the configured base URL is blank or whitespace
- add unit tests covering whitespace bases and relative URL fallbacks

## Testing
- npm test -- --run *(fails: vitest: not found in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d701b5d4c08329968f64fef7dcc65b