### PR TITLE
Handle blank API base URLs using the app base

### DIFF
--- a/apps/ui/src/lib/api.test.ts
+++ b/apps/ui/src/lib/api.test.ts
@@ -1,14 +1,21 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { buildUrl } from './api';
 
-const env = import.meta.env as { VITE_API_BASE_URL?: string };
+const env = import.meta.env as { VITE_API_BASE_URL?: string; BASE_URL?: string };
 const originalBase = env.VITE_API_BASE_URL;
+const originalAppBase = env.BASE_URL;
 
 afterEach(() => {
   if (originalBase === undefined) {
     delete env.VITE_API_BASE_URL;
   } else {
     env.VITE_API_BASE_URL = originalBase;
+  }
+
+  if (originalAppBase === undefined) {
+    delete env.BASE_URL;
+  } else {
+    env.BASE_URL = originalAppBase;
   }
 });
 
@@ -21,8 +28,16 @@ describe('buildUrl', () => {
 
   it('falls back to a relative path when the base URL is whitespace', () => {
     env.VITE_API_BASE_URL = '   ';
+    env.BASE_URL = '/';
 
     expect(buildUrl(' invoices ')).toBe('/invoices');
+  });
+
+  it('uses the application base URL when the API base is blank', () => {
+    env.VITE_API_BASE_URL = '   ';
+    env.BASE_URL = '/portal/';
+
+    expect(buildUrl('  /workspace/items ')).toBe('/portal/workspace/items');
   });
 
   it('uses relative paths when no base URL is set', () => {

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -63,19 +63,31 @@ export const normaliseErrorDetail = (detail: unknown): string => {
 
 export const buildUrl = (path: string): string => {
   const rawBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '';
-  const base = rawBase.trim();
   const trimmedPath = path.trim();
 
-  if (!base) {
-    if (!trimmedPath) return '/';
-    return trimmedPath.startsWith('/') ? trimmedPath : `/${trimmedPath}`;
+  let effectiveBase = rawBase.trim();
+
+  if (!effectiveBase) {
+    const rawAppBase = (import.meta.env.BASE_URL as string | undefined) ?? '';
+    const appBase = rawAppBase.trim();
+    if (appBase && appBase !== '/') {
+      effectiveBase = appBase;
+    }
   }
 
-  const normalisedBase = base.replace(/\/+$/, '');
+  if (!effectiveBase) {
+    const normalisedRelativePath = trimmedPath.replace(/^\/+/, '');
+    if (!normalisedRelativePath) {
+      return '/';
+    }
+    return `/${normalisedRelativePath}`;
+  }
+
+  const normalisedBase = effectiveBase.replace(/\/+$/, '');
   const normalisedPath = trimmedPath.replace(/^\/+/, '');
 
   if (!normalisedPath) {
-    return normalisedBase;
+    return normalisedBase || '/';
   }
 
   return `${normalisedBase}/${normalisedPath}`;


### PR DESCRIPTION
## Summary
- derive the API URL prefix from the Vite app base when the API base env var is blank while keeping slash guards
- normalise fallback paths so empty or slash-only requests still resolve to the root
- cover the portal deployment scenario with a new buildUrl test

## Testing
- pnpm test *(fails: vitest command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d705fcf22c8329aad9c562a26355c9