### PR TITLE
Expose OCR metadata and confidence in invoice extraction

### DIFF
--- a/docs/repository_architecture_review.md
+++ b/docs/repository_architecture_review.md
@@ -1,0 +1,99 @@
+# AI-Invoice-Knowledge Repository Review and Integration Roadmap
+
+## Executive Summary
+The AI-Invoice-Knowledge codebase already offers end-to-end invoice digitization through OCR, NLP extraction, classification, predictive modeling, and multi-language client integrations. However, each capability is largely implemented as an independent vertical slice. This review surfaces the structural strengths, identifies cross-cutting risks, and outlines a practical plan to converge the pieces into a cohesive, production-ready platform.
+
+## Architectural Observations
+### Overall Structure
+- **Python core (`src/ai_invoice/`)**: Houses configuration helpers, OCR logic, rule-based NLP parsing, classifier utilities, and predictive features. The modules follow a logical separation of concerns but rely on implicit conventions rather than explicit contracts across components.
+- **API layer (`src/api/`)**: Provides FastAPI routes, middleware, and schema definitions that stitch together the Python services. It already exposes health checks, extraction, classification, and prediction endpoints.
+- **Operations assets (`docs/`, `scripts/`, `apps/`)**: Supply documentation, UI portals, and automation scripts. These artifacts are valuable but not always reflected in code-level abstractions.
+- **.NET integration (`dotnet/`)**: Demonstrates a companion client and API wrapper. It remains largely detached from Python configuration and deployment practices.
+
+### Configuration & Settings Management
+- Configuration is centralized in `config.py` with environment overrides and persisted JSON settings. The settings system is powerful yet duplicated across the API, CLI scripts, and .NET client. A shared contract for configuration fields would reduce drift.
+- Suggestion: publish a typed configuration schema (e.g., Pydantic `BaseSettings` + JSON schema export) and generate matching DTOs for the .NET client.
+
+### OCR Pipeline
+- `ocr/engine.py` and `ocr/postprocess.py` orchestrate PDF ingestion, page rendering, Tesseract OCR, and text cleanup. The functions are composable but lack standardized outputs (e.g., confidence scores, structured layout). A more explicit `OCRResult` dataclass would help downstream consumers interpret outputs consistently.
+- Consider modularizing engine configuration (language packs, DPI, preprocessing toggles) so the API, CLI tools, and agents can reuse the same pipeline definition.
+
+### NLP Extraction
+- `nlp_extract/parser.py` couples regex heuristics with structured extraction logic. The rules are clear yet manually curated. Integrating a pluggable rule registry or spaCy pipeline would enable gradual expansion.
+- Surfacing extraction confidence and field provenance (regex, OCR, manual override) would support UI validation and downstream analytics.
+
+### Classification & Predictive Modeling
+- Classification (`classify/model.py`) and predictive scoring (`predictive/model.py`) each wrap scikit-learn models loaded from disk. The prediction flows are straightforward but could benefit from:
+  - Unified feature preprocessing (feature store or transformer pipeline).
+  - Versioned model metadata (training data summary, metrics, schema expectations).
+  - A consistent interface exposing `load`, `predict`, and `update` semantics.
+- Current training scripts in `scripts/` are useful for offline experimentation but not tied to the API lifecycle (no background retraining jobs, no monitoring).
+
+### API & Middleware
+- The API routes in `src/api/routers/` cleanly separate health, invoice, and model management functionality. However, rate limiting, API key enforcement, and request validation are dispersed across middleware and route handlers, creating room for mistakes.
+- Proposal: implement a declarative dependency stack (authentication, payload size guard, rate limiting) and reuse it across routes via FastAPI dependencies.
+- API responses should embed trace IDs and emit structured logs to ease distributed debugging once the service scales.
+
+### Front-End & Portal
+- The existing `apps/` directory hosts a simple portal for file uploads and model management. Because it communicates with the API directly, ensuring schema parity (e.g., via OpenAPI client generation) would prevent runtime mismatches.
+- Consolidating the UI into a dedicated `frontend/` package with build tooling (Vite/React or Svelte) can improve developer ergonomics and deployment consistency.
+
+### .NET Integration
+- The `AIInvoiceSystem.Core` project defines DTOs and an `AIClient` wrapper with retry policies. Its configuration (base URL, API key) is derived from environment variables but not synchronized with Python defaults.
+- Introduce OpenAPI-generated clients to avoid manually maintaining DTOs. Align API key management with Python service conventions, possibly through a shared `.env` template or secrets manager.
+
+## Integration Recommendations
+1. **Define Shared Domain Contracts**
+   - Create Pydantic models that represent canonical entities (InvoiceDocument, ExtractedInvoice, ClassificationResult, PaymentPrediction).
+   - Export JSON schemas and generate TypeScript and C# DTOs from the same definitions to unify API, UI, and .NET consumers.
+
+2. **Standardize Pipeline Interfaces**
+   - Wrap OCR, NLP, classification, and prediction modules behind service classes with explicit input/output types.
+   - Adopt dependency injection (via FastAPI or a lightweight container) so routes receive fully configured services.
+
+3. **Model Lifecycle Alignment**
+   - Store model artifacts alongside metadata (version, training metrics, feature schema) in `models/manifest.json`.
+   - Extend `/models/*` endpoints to expose version info and support staged deployments (shadow mode, A/B testing).
+   - Automate retraining with orchestrated jobs (GitHub Actions, Airflow, or Prefect) writing outputs back into versioned storage.
+
+4. **Configuration Harmonization**
+   - Consolidate configuration into `settings.json` + environment overrides, with a formal schema validated at startup.
+   - Provide CLI commands (e.g., `ai-invoice config get/set`) and ensure the .NET client reads the same configuration source or a synchronized export.
+
+5. **Observability & Reliability**
+   - Introduce structured logging, trace IDs, and metrics (Prometheus/OpenTelemetry) for API endpoints and background tasks.
+   - Implement centralized error handling to translate exceptions into consistent API responses and user-facing messages.
+   - Harden middleware by creating reusable FastAPI dependencies for authentication, payload limits, and rate limiting.
+
+6. **Cross-Language Integration Strategy**
+   - Evaluate gRPC or REST+JSON with schema-generated clients for Python ↔ .NET communication.
+   - Package the Python service into a container image with explicit health checks; allow the .NET app to orchestrate the container or call the deployed service remotely.
+
+7. **Developer Experience Enhancements**
+   - Document end-to-end flows (OCR → NLP → classification → prediction) with sequence diagrams in `docs/`.
+   - Provide `make` or `invoke` commands to run common tasks (tests, linting, model evaluation).
+   - Add unit/integration tests covering OCR fallbacks, extraction edge cases, and API contract tests.
+
+## Phased Roadmap
+1. **Foundational Alignment (Weeks 1–2)**
+   - Publish shared schemas and generate clients.
+   - Refactor services to consume typed pipelines and shared configuration.
+   - Establish automated tests for core modules and API endpoints.
+
+2. **Lifecycle & Observability (Weeks 3–4)**
+   - Add model metadata management and extended `/models` routes.
+   - Instrument logging, metrics, and tracing.
+   - Harden middleware and error handling.
+
+3. **Productization (Weeks 5–6)**
+   - Containerize the service, set up CI/CD pipelines, and define deployment environments.
+   - Align .NET integration with generated clients and shared configuration sources.
+   - Enhance the front-end portal to consume generated SDKs and surface confidence/trace information.
+
+4. **Continuous Improvement (Week 7+)**
+   - Expand OCR/NLP coverage via plugin architecture and data-driven rule tuning.
+   - Implement automated retraining pipelines with monitoring.
+   - Explore advanced orchestration (LangGraph agents, workflow automation) built atop the consolidated APIs.
+
+## Conclusion
+By formalizing shared contracts, standardizing service interfaces, and aligning configuration and model lifecycle management across Python and .NET components, AI-Invoice-Knowledge can mature from a collection of powerful capabilities into a cohesive, production-ready platform. The recommendations above prioritize predictable integration, maintainability, and long-term scalability while preserving the flexibility of the existing modular design.

--- a/dotnet/AIInvoiceSystem.Core/AIClient.cs
+++ b/dotnet/AIInvoiceSystem.Core/AIClient.cs
@@ -310,7 +310,8 @@ public sealed record InvoiceExtractionDto(
     string? buyer_name,
     string? buyer_tax_id,
     List<LineItemDto> items,
-    string raw_text);
+    string raw_text,
+    double? ocr_confidence);
 
 public sealed record ClassificationResultDto(string label, double proba);
 

--- a/src/ai_invoice/nlp_extract/parser.py
+++ b/src/ai_invoice/nlp_extract/parser.py
@@ -7,7 +7,7 @@ from ..ocr.postprocess import clean_text, normalize_amount
 from ..schemas import InvoiceExtraction, LineItem
 
 
-def parse_structured(raw: str) -> InvoiceExtraction:
+def parse_structured(raw: str, *, ocr_confidence: float | None = None) -> InvoiceExtraction:
     txt = clean_text(raw)
     invoice_number = first_regex(txt, PATTERNS["invoice_number"])
     invoice_date = first_regex(txt, PATTERNS["invoice_date"])
@@ -46,4 +46,5 @@ def parse_structured(raw: str) -> InvoiceExtraction:
         buyer_tax_id=None,
         items=items,
         raw_text=txt,
+        ocr_confidence=ocr_confidence,
     )

--- a/src/ai_invoice/ocr/__init__.py
+++ b/src/ai_invoice/ocr/__init__.py
@@ -1,0 +1,6 @@
+from .engine import pdf_or_image_to_text, run_ocr
+
+__all__ = [
+    "pdf_or_image_to_text",
+    "run_ocr",
+]

--- a/src/ai_invoice/ocr/engine.py
+++ b/src/ai_invoice/ocr/engine.py
@@ -1,20 +1,74 @@
 from __future__ import annotations
 
 import io
+from statistics import fmean
+from typing import Iterable
 
 import pytesseract
 from pdf2image import convert_from_bytes
 from PIL import Image
 
+from ai_invoice.schemas import OCRPage, OCRResult
 
-def _img_to_text(img: Image.Image) -> str:
-    return pytesseract.image_to_string(img, config="--oem 3 --psm 6")
+
+_TESSERACT_CONFIG = "--oem 3 --psm 6"
+
+
+def _page_confidence(confidences: Iterable[str]) -> float | None:
+    """Compute the average confidence from the Tesseract output."""
+
+    cleaned: list[float] = []
+    for value in confidences:
+        if not value or value == "-1":
+            continue
+        try:
+            cleaned.append(float(value))
+        except ValueError:
+            continue
+    if not cleaned:
+        return None
+    return float(fmean(cleaned))
+
+
+def _image_to_page(img: Image.Image, page_number: int) -> OCRPage:
+    text = pytesseract.image_to_string(img, config=_TESSERACT_CONFIG).strip()
+    data = pytesseract.image_to_data(img, config=_TESSERACT_CONFIG, output_type=pytesseract.Output.DICT)
+    confidence = _page_confidence(data.get("conf", []))
+    width, height = img.size
+    return OCRPage(
+        page_number=page_number,
+        text=text,
+        confidence=confidence,
+        width=int(width),
+        height=int(height),
+    )
+
+
+def run_ocr(file_bytes: bytes) -> OCRResult:
+    is_pdf = file_bytes[:5] == b"%PDF-"
+    pages: list[OCRPage] = []
+    if is_pdf:
+        for index, page in enumerate(convert_from_bytes(file_bytes, dpi=300), start=1):
+            pages.append(_image_to_page(page, index))
+        source = "pdf"
+    else:
+        image = Image.open(io.BytesIO(file_bytes)).convert("RGB")
+        pages.append(_image_to_page(image, 1))
+        source = "image"
+
+    text = "\n\n".join(page.text for page in pages).strip()
+    confidences = [page.confidence for page in pages if page.confidence is not None]
+    average_confidence = float(fmean(confidences)) if confidences else None
+
+    return OCRResult(
+        source=source,
+        text=text,
+        average_confidence=average_confidence,
+        pages=pages,
+    )
 
 
 def pdf_or_image_to_text(file_bytes: bytes) -> str:
-    is_pdf = file_bytes[:5] == b"%PDF-"
-    if is_pdf:
-        pages = convert_from_bytes(file_bytes, dpi=300)
-        return "\n\n".join(_img_to_text(page) for page in pages)
-    image = Image.open(io.BytesIO(file_bytes)).convert("RGB")
-    return _img_to_text(image)
+    """Backward-compatible helper returning only the recognized text."""
+
+    return run_ocr(file_bytes).text

--- a/src/ai_invoice/schemas.py
+++ b/src/ai_invoice/schemas.py
@@ -1,7 +1,22 @@
-from typing import List
-from typing import Optional
+from typing import List, Optional
+from typing import Literal
 
 from pydantic import BaseModel, Field
+
+
+class OCRPage(BaseModel):
+    page_number: int
+    text: str
+    confidence: Optional[float] = None
+    width: int
+    height: int
+
+
+class OCRResult(BaseModel):
+    source: Literal["pdf", "image"]
+    text: str
+    average_confidence: Optional[float] = None
+    pages: List[OCRPage] = Field(default_factory=list)
 
 
 class LineItem(BaseModel):
@@ -25,6 +40,7 @@ class InvoiceExtraction(BaseModel):
     buyer_tax_id: Optional[str]
     items: List[LineItem] = Field(default_factory=list)
     raw_text: str
+    ocr_confidence: Optional[float] = None
 
 
 class ClassificationResult(BaseModel):

--- a/src/ai_invoice/service.py
+++ b/src/ai_invoice/service.py
@@ -4,14 +4,16 @@ import numpy as np
 
 from .classify.model import predict_proba_texts
 from .nlp_extract.parser import parse_structured
-from .ocr.engine import pdf_or_image_to_text
+from .ocr.engine import run_ocr
 from .predictive.model import predict_payment_days
 from .schemas import ClassificationResult, InvoiceExtraction, PredictiveResult
 
 
 def extract_invoice(file_bytes: bytes) -> InvoiceExtraction:
-    text = pdf_or_image_to_text(file_bytes)
-    return parse_structured(text)
+    ocr_result = run_ocr(file_bytes)
+    extraction = parse_structured(ocr_result.text, ocr_confidence=ocr_result.average_confidence)
+    extraction.raw_text = ocr_result.text
+    return extraction
 
 
 def classify_text(raw_text: str) -> ClassificationResult:


### PR DESCRIPTION
## Summary
- introduce structured OCRResult and OCRPage schemas that capture page dimensions and confidence values
- refactor the OCR engine to return rich metadata while maintaining the legacy text-only helper
- propagate OCR confidence through the extraction service and client DTOs so downstream consumers receive the score

## Testing
- pytest *(fails: missing optional dependencies such as fastapi in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d704d86b8c8329b030a141049fcfb7