### PR TITLE
Fix API base fallback handling for root paths

### DIFF
--- a/apps/ui/src/lib/api.test.ts
+++ b/apps/ui/src/lib/api.test.ts
@@ -33,11 +33,12 @@ describe('buildUrl', () => {
     expect(buildUrl(' invoices ')).toBe('/invoices');
   });
 
-  it('uses the application base URL when the API base is blank', () => {
+  it('uses the application base URL for relative paths when the API base is blank', () => {
     env.VITE_API_BASE_URL = '   ';
     env.BASE_URL = '/portal/';
 
-    expect(buildUrl('  /workspace/items ')).toBe('/portal/workspace/items');
+    expect(buildUrl('  /workspace/items ')).toBe('/workspace/items');
+    expect(buildUrl(' workspace/items ')).toBe('/portal/workspace/items');
   });
 
   it('uses relative paths when no base URL is set', () => {

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -65,9 +65,11 @@ export const buildUrl = (path: string): string => {
   const rawBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '';
   const trimmedPath = path.trim();
 
+  const isRelativePath = !trimmedPath.startsWith('/');
+
   let effectiveBase = rawBase.trim();
 
-  if (!effectiveBase) {
+  if (!effectiveBase && isRelativePath) {
     const rawAppBase = (import.meta.env.BASE_URL as string | undefined) ?? '';
     const appBase = rawAppBase.trim();
     if (appBase && appBase !== '/') {


### PR DESCRIPTION
## Summary
- ensure `buildUrl` only falls back to the application BASE_URL when resolving relative request paths
- update portal URL unit test to expect root-anchored requests to bypass the application base and to verify the relative-path fallback

## Testing
- `pnpm test src/lib/api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68d70e4931608329988a4e0b6033f19e