### PR TITLE
Replace OpenSSL license verification with cryptography

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "spacy>=3.7",
   "faker>=25.0",
   "deepagents>=0.0.7",
+  "cryptography>=42.0",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- switch license verification to use the cryptography Ed25519 primitives instead of spawning the OpenSSL CLI
- cache the loaded public key and validate PEM input before verification
- declare the new cryptography dependency for the Python package

## Testing
- pytest *(fails: missing optional dependencies like fastapi in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d70ea138b08329be72a2f875eb33f2