### PR TITLE
Integrate React console with FastAPI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 ai_invoice_api*
 *.joblib
 !models/*.joblib
+node_modules/

--- a/README.md
+++ b/README.md
@@ -187,3 +187,20 @@ Use `AIClient` in your controllers or background services once registered.
 * Broaden the dataset and labels for the classifier and predictive models.
 * Add retries, telemetry, and circuit breakers on the .NET side.
 * Experiment with LangGraph deep agents to orchestrate invoice automation end-to-end (see [`docs/deep_agents.md`](docs/deep_agents.md)).
+
+## Unified local workflow (React + FastAPI)
+
+To run the React workspace against the FastAPI service during development:
+
+1. Follow the Python service steps above and keep `uvicorn` running (default port `8088`).
+2. In another terminal:
+
+   ```bash
+   cd apps/ui
+   cp .env.example .env.local # optional but recommended
+   npm install
+   npm run dev
+   ```
+
+3. Visit `http://localhost:5173`, open **Settings → API access**, and paste your `X-API-Key` and `X-License` values. The UI now calls
+   the live endpoints (`/workspace/...`, `/invoices/...`, etc.) directly.

--- a/apps/ui/.env.example
+++ b/apps/ui/.env.example
@@ -1,0 +1,2 @@
+# URL for the FastAPI service. Leave blank to use relative paths against the UI host.
+VITE_API_BASE_URL=http://localhost:8088

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -11,10 +11,27 @@ Minimalist dual-theme React + Tailwind dashboard for the AI Invoice platform. Th
 
 ```bash
 npm install
+cp .env.example .env.local # optional but recommended
 npm run dev
 ```
 
 Then open `http://localhost:5173` in your browser.
+
+## Connecting to the FastAPI backend
+
+1. Start the Python service (from the repository root):
+
+   ```bash
+   uv run uvicorn api.main:app --reload --port 8088
+   ```
+
+2. Configure the UI with the backend host by editing `.env.local` (copied from `.env.example`). For a default local setup this is
+   `VITE_API_BASE_URL=http://localhost:8088`.
+
+3. Once the workspace loads, open **Settings → API access** and paste your `X-API-Key` and `X-License` tokens. The console stores
+   them in the browser and automatically includes them with every request.
+
+4. Use the dashboard, invoice viewer, and other sections normally. They now stream live data from the FastAPI endpoints.
 
 To create a production build:
 
@@ -46,4 +63,5 @@ The UI uses Indigo `#3F51B5` as the primary color with Costa Rica accents (`#CE1
 
 ## Mock data
 
-All dashboards, tables, and workflows use static mocks under `src/data/mockData.ts`. Swap these with live fetches (e.g., `/invoices`, `/vendors`, `/approvals`) once backend endpoints are ready.
+Legacy mock payloads live under `src/data/mockData.ts` for reference. The hooks in `src/hooks/useWorkspaceData.ts` now call the
+FastAPI endpoints by default, so you only need the mocks when working offline.

--- a/apps/ui/src/hooks/useCredentials.ts
+++ b/apps/ui/src/hooks/useCredentials.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  StoredCredentials,
+  clearStoredCredentials,
+  credentialsStorageKey,
+  readStoredCredentials,
+  writeStoredCredentials
+} from '../lib/credentials';
+
+type CredentialsState = StoredCredentials;
+
+type CredentialsHook = {
+  credentials: CredentialsState;
+  setCredentials: (next: StoredCredentials) => void;
+  clearCredentials: () => void;
+};
+
+export const useCredentials = (): CredentialsHook => {
+  const [credentials, setCredentialsState] = useState<CredentialsState>(() => readStoredCredentials());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === credentialsStorageKey) {
+        setCredentialsState(readStoredCredentials());
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  const setCredentials = useCallback((next: StoredCredentials) => {
+    const normalized = writeStoredCredentials(next);
+    setCredentialsState(normalized);
+  }, []);
+
+  const clearCredentialsFn = useCallback(() => {
+    clearStoredCredentials();
+    setCredentialsState({});
+  }, []);
+
+  return {
+    credentials,
+    setCredentials,
+    clearCredentials: clearCredentialsFn
+  };
+};

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { readStoredCredentials } from './credentials';
+
 export class ApiError extends Error {
   status: number;
   payload: unknown;
@@ -9,30 +11,6 @@ export class ApiError extends Error {
     this.payload = payload;
   }
 }
-
-const STORAGE_KEY = 'ai-invoice-portal.credentials';
-
-type StoredCredentials = {
-  apiKey?: string;
-  licenseToken?: string;
-};
-
-const readCredentials = (): StoredCredentials => {
-  if (typeof window === 'undefined' || !window.localStorage) {
-    return {};
-  }
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as StoredCredentials;
-    return {
-      apiKey: parsed.apiKey?.trim() || undefined,
-      licenseToken: parsed.licenseToken?.trim() || undefined
-    };
-  } catch {
-    return {};
-  }
-};
 
 export const normaliseErrorDetail = (detail: unknown): string => {
   if (detail == null) return 'Unexpected error.';
@@ -102,7 +80,7 @@ type RequestOptions = {
 };
 
 const request = async <T>(path: string, options: RequestOptions = {}): Promise<T> => {
-  const { apiKey, licenseToken } = readCredentials();
+  const { apiKey, licenseToken } = readStoredCredentials();
   const headers = new Headers(options.headers);
   headers.set('Accept', 'application/json');
   if (apiKey) headers.set('X-API-Key', apiKey);

--- a/apps/ui/src/lib/credentials.ts
+++ b/apps/ui/src/lib/credentials.ts
@@ -1,0 +1,53 @@
+const STORAGE_KEY = 'ai-invoice-portal.credentials';
+
+export type StoredCredentials = {
+  apiKey?: string;
+  licenseToken?: string;
+};
+
+const normalize = (value: StoredCredentials): StoredCredentials => ({
+  apiKey: value.apiKey?.trim() || undefined,
+  licenseToken: value.licenseToken?.trim() || undefined
+});
+
+export const readStoredCredentials = (): StoredCredentials => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return {};
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as StoredCredentials;
+    return normalize(parsed);
+  } catch {
+    return {};
+  }
+};
+
+export const writeStoredCredentials = (value: StoredCredentials): StoredCredentials => {
+  const normalized = normalize(value);
+  if (typeof window !== 'undefined' && window.localStorage) {
+    try {
+      if (normalized.apiKey || normalized.licenseToken) {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
+      } else {
+        window.localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch {
+      // Ignore storage errors (private mode, quotas, etc.)
+    }
+  }
+  return normalized;
+};
+
+export const clearStoredCredentials = (): void => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+  }
+};
+
+export const credentialsStorageKey = STORAGE_KEY;

--- a/apps/ui/src/sections/SettingsSection.tsx
+++ b/apps/ui/src/sections/SettingsSection.tsx
@@ -1,12 +1,140 @@
+import { type FormEvent, useEffect, useMemo, useState } from 'react';
 import { Card } from '../components/Card';
+import { useCredentials } from '../hooks/useCredentials';
 import { ThemeMode, useTheme } from '../hooks/useTheme';
 import { accentSwatches, settingToggles } from '../data/settings';
 
 export const SettingsSection = () => {
   const { mode, setMode, effectiveTheme } = useTheme();
+  const { credentials, setCredentials, clearCredentials } = useCredentials();
+  const [apiKeyInput, setApiKeyInput] = useState(credentials.apiKey ?? '');
+  const [licenseInput, setLicenseInput] = useState(credentials.licenseToken ?? '');
+  const [feedback, setFeedback] = useState<'idle' | 'saved' | 'cleared'>('idle');
+
+  useEffect(() => {
+    setApiKeyInput(credentials.apiKey ?? '');
+    setLicenseInput(credentials.licenseToken ?? '');
+  }, [credentials]);
+
+  useEffect(() => {
+    if (feedback === 'idle' || typeof window === 'undefined') {
+      return;
+    }
+    const timer = window.setTimeout(() => setFeedback('idle'), 4000);
+    return () => window.clearTimeout(timer);
+  }, [feedback]);
+
+  const hasStoredCredentials = Boolean(credentials.apiKey || credentials.licenseToken);
+
+  const { baseDisplay, baseDescription } = useMemo(() => {
+    const envBase = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.trim();
+    if (envBase) {
+      return {
+        baseDisplay: envBase,
+        baseDescription: 'Configured via VITE_API_BASE_URL. Update your .env file to point at a different FastAPI host.'
+      };
+    }
+    if (typeof window !== 'undefined') {
+      return {
+        baseDisplay: `${window.location.origin} (relative)`,
+        baseDescription:
+          'No VITE_API_BASE_URL supplied. Requests default to relative paths on the same host as this UI.'
+      };
+    }
+    return {
+      baseDisplay: 'Relative to current origin',
+      baseDescription: 'Requests default to relative paths on the same host as this UI.'
+    };
+  }, []);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setCredentials({ apiKey: apiKeyInput, licenseToken: licenseInput });
+    setFeedback(apiKeyInput || licenseInput ? 'saved' : 'cleared');
+  };
+
+  const handleClear = () => {
+    setApiKeyInput('');
+    setLicenseInput('');
+    clearCredentials();
+    setFeedback('cleared');
+  };
 
   return (
     <div className="grid gap-6 lg:grid-cols-2">
+      <Card title="API access" eyebrow="Backend connection" className="lg:col-span-2">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <p>
+            Provide the credentials issued for your workspace so the console can authenticate with the FastAPI service. They stay
+            in this browser only and can be cleared at any time.
+          </p>
+
+          <div>
+            <label className="block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              API key
+            </label>
+            <input
+              type="password"
+              autoComplete="off"
+              value={apiKeyInput}
+              onChange={(event) => {
+                setApiKeyInput(event.target.value);
+                setFeedback('idle');
+              }}
+              placeholder="X-API-Key header"
+              className="mt-1 w-full rounded-xl border border-slate-200 bg-white/90 px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-indigoBrand focus:outline-none focus:ring-2 focus:ring-indigoBrand/40 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              License token
+            </label>
+            <input
+              type="password"
+              autoComplete="off"
+              value={licenseInput}
+              onChange={(event) => {
+                setLicenseInput(event.target.value);
+                setFeedback('idle');
+              }}
+              placeholder="X-License header"
+              className="mt-1 w-full rounded-xl border border-slate-200 bg-white/90 px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-indigoBrand focus:outline-none focus:ring-2 focus:ring-indigoBrand/40 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100"
+            />
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="submit"
+              className="rounded-full bg-indigoBrand px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigoBrand/90 focus:outline-none focus:ring-2 focus:ring-indigoBrand/40 disabled:cursor-not-allowed disabled:bg-indigoBrand/50"
+            >
+              Save credentials
+            </button>
+            <button
+              type="button"
+              onClick={handleClear}
+              disabled={!hasStoredCredentials && !apiKeyInput && !licenseInput}
+              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-400 hover:text-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+            >
+              Clear
+            </button>
+          </div>
+
+          <div className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+            <p>
+              API base URL: <code className="rounded bg-slate-200 px-1 py-0.5 text-[0.7rem] dark:bg-slate-800">{baseDisplay}</code>
+            </p>
+            <p>{baseDescription}</p>
+            {feedback === 'saved' && (
+              <p className="font-semibold text-crGreen dark:text-crGreen">Credentials saved. New requests will include them automatically.</p>
+            )}
+            {feedback === 'cleared' && (
+              <p className="font-semibold text-slate-600 dark:text-slate-300">Stored credentials removed for this browser.</p>
+            )}
+          </div>
+        </form>
+      </Card>
+
       <Card title="Appearance" eyebrow="Personalize">
         <p className="text-sm">
           Choose between light, dark, or match the system setting. Preferences persist across sessions.


### PR DESCRIPTION
## Summary
- add a credentials storage helper/hook and surface an API access card so the React console persists the FastAPI headers
- document the workflow for running the React UI alongside the FastAPI service and ship a Vite environment template
- update repository ignores to prevent accidental node_modules check-ins

## Testing
- npm test -- --run *(fails: existing vitest suites time out around ApprovalsSection mocks and a duplicate text assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68d70dd229048329be7355fb8d0f64f4