### PR TITLE
Upgrade UI lint tooling for ESLint 9 and Vite 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 ai_invoice_api*
 *.joblib
 !models/*.joblib
+node_modules/
+src/api/static/console/

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -1,0 +1,64 @@
+# AI Invoice Console UI
+
+Minimalist, Costa Rica–inspired React + Tailwind dashboard for the AI Invoice platform. The console embraces an original "Aurora" shell with custom gradients, card auras, and typography that keep the experience unmistakably ours while shipping mocked data so it can be explored offline and later wired to live APIs.
+
+## Prerequisites
+
+- Node.js 18+
+- npm 9+
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+Then open `http://localhost:5173` in your browser.
+
+To create a production build:
+
+```bash
+npm run build
+```
+
+This writes the compiled bundle to `src/api/static/console/` so FastAPI can serve it from `/portal` without running the Vite
+dev server. Re-run the command whenever UI changes need to ship with the backend.
+
+### Serving through FastAPI
+
+After building, start the Python API (for example `uvicorn api.main:app --reload --port 8088`) and visit
+`http://127.0.0.1:8088/portal`. FastAPI automatically serves the latest build, while the legacy Jinja console remains
+available at `/portal/legacy` as a fallback.
+
+### Project structure
+
+```
+apps/ui
+├── package.json
+├── index.html
+├── src
+│   ├── App.tsx
+│   ├── components
+│   ├── data
+│   ├── hooks
+│   └── sections
+├── tailwind.config.js
+└── tsconfig.json
+```
+
+## Theming
+
+The UI uses Indigo `#3F51B5` as the primary color with bespoke Costa Rica accents (`#002B7F`, `#CE1126`, and our sunrise `#F4A71D`) while supporting light, dark, and system themes. Preferences persist via `localStorage`, animate the gradient theme toggle, and automatically react to OS theme changes.
+
+## Mock data
+
+All dashboards, tables, and workflows use static mocks under `src/data/mockData.ts`. Swap these with live fetches (e.g., `/invoices`, `/vendors`, `/approvals`) once backend endpoints are ready.
+
+## Design language
+
+- **Aurora backdrop:** Layered gradients and wave motifs in `BrandBackdrop.tsx` reference Costa Rican skies and coastlines without reusing competitor layouts.
+- **Signature navigation:** Sidebar tiles, accent pills, and typography create a "PuraFlow" voice distinct from any reference inspiration.
+- **Immersive cards:** `Card.tsx` introduces custom aura glows and tricolor footers so data blocks feel handcrafted.
+
+These patterns make the console visually unique while staying within our minimalist brand direction.

--- a/apps/ui/eslint.config.js
+++ b/apps/ui/eslint.config.js
@@ -1,0 +1,36 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import js from '@eslint/js';
+import reactPlugin from 'eslint-plugin-react';
+import tseslint from 'typescript-eslint';
+
+const tsconfigRootDir = path.dirname(fileURLToPath(import.meta.url));
+
+export default tseslint.config(
+  {
+    ignores: ['dist', 'coverage', 'build', 'src/api/static/console'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir,
+      },
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+  },
+  reactPlugin.configs.flat.recommended,
+  reactPlugin.configs.flat['jsx-runtime'],
+  {
+    rules: {
+      'react/prop-types': 'off',
+    },
+  }
+);

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" class="h-full">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Invoice Console</title>
+  </head>
+  <body class="h-full bg-slate-100">
+    <div id="root" class="h-full"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "ai-invoice-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --max-warnings 0"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.14.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^5.0.3",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^9.14.0",
+    "eslint-config-prettier": "^10.1.1",
+    "eslint-plugin-react": "^7.37.2",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.6.3",
+    "typescript-eslint": "^8.13.0",
+    "vite": "^7.1.7"
+  }
+}

--- a/apps/ui/postcss.config.js
+++ b/apps/ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1,0 +1,100 @@
+import { useMemo, useState } from 'react';
+import { ThemeProvider } from './hooks/useTheme';
+import { Sidebar } from './components/Sidebar';
+import { TopBar } from './components/TopBar';
+import { BrandBackdrop } from './components/BrandBackdrop';
+import { DashboardSection } from './sections/DashboardSection';
+import { InvoiceViewerSection } from './sections/InvoiceViewerSection';
+import { VendorListSection } from './sections/VendorListSection';
+import { ReportsSection } from './sections/ReportsSection';
+import { ApprovalsSection } from './sections/ApprovalsSection';
+import { SettingsSection } from './sections/SettingsSection';
+
+export type AppSectionKey =
+  | 'dashboard'
+  | 'invoices'
+  | 'vendors'
+  | 'reports'
+  | 'approvals'
+  | 'settings';
+
+type SectionItem = {
+  id: AppSectionKey;
+  label: string;
+  description: string;
+  component: JSX.Element;
+};
+
+const useSections = (): SectionItem[] =>
+  useMemo(
+    () => [
+      {
+        id: 'dashboard',
+        label: 'Dashboard',
+        description: 'Pulse of your invoice operations at a glance.',
+        component: <DashboardSection />
+      },
+      {
+        id: 'invoices',
+        label: 'Invoice Viewer',
+        description: 'Details, line items, and actions for the current invoice.',
+        component: <InvoiceViewerSection />
+      },
+      {
+        id: 'vendors',
+        label: 'Vendors',
+        description: 'Searchable directory of suppliers with contact details.',
+        component: <VendorListSection />
+      },
+      {
+        id: 'reports',
+        label: 'Reports',
+        description: 'Download-ready summaries and insights for finance teams.',
+        component: <ReportsSection />
+      },
+      {
+        id: 'approvals',
+        label: 'Approvals',
+        description: 'Fast approval workflow with delightful micro-animations.',
+        component: <ApprovalsSection />
+      },
+      {
+        id: 'settings',
+        label: 'Settings',
+        description: 'Theme controls, notifications, and workspace preferences.',
+        component: <SettingsSection />
+      }
+    ],
+    []
+  );
+
+const AppShell = () => {
+  const sections = useSections();
+  const [active, setActive] = useState<AppSectionKey>('dashboard');
+  const current = sections.find((section) => section.id === active) ?? sections[0];
+
+  return (
+    <div className="relative flex h-full min-h-screen bg-transparent text-slate-700 dark:text-slate-200">
+      <BrandBackdrop />
+      <Sidebar
+        sections={sections.map(({ id, label }) => ({ id, label }))}
+        active={active}
+        onSelect={setActive}
+      />
+      <div className="relative z-10 flex flex-1 flex-col">
+        <TopBar title={current.label} description={current.description} />
+        <main className="flex-1 overflow-y-auto px-6 pb-12 pt-6 sm:px-10">
+          <div className="mx-auto max-w-6xl space-y-8">{current.component}</div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+const App = () => (
+  <ThemeProvider>
+    <AppShell />
+  </ThemeProvider>
+);
+
+export default App;

--- a/apps/ui/src/components/BrandBackdrop.tsx
+++ b/apps/ui/src/components/BrandBackdrop.tsx
@@ -1,0 +1,17 @@
+export const BrandBackdrop = () => {
+  return (
+    <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+      <div className="absolute -left-32 -top-24 h-[28rem] w-[28rem] rounded-full bg-[radial-gradient(circle_at_30%_20%,rgba(63,81,181,0.28),rgba(63,81,181,0))] blur-3xl opacity-80 dark:opacity-70" aria-hidden></div>
+      <div className="absolute right-[-18%] top-[12%] h-[30rem] w-[30rem] rounded-[48%] bg-[radial-gradient(circle_at_70%_30%,rgba(0,43,127,0.22),rgba(0,43,127,0))] blur-3xl opacity-70 dark:opacity-60" aria-hidden></div>
+      <div className="absolute bottom-[-26%] left-1/2 h-[24rem] w-[36rem] -translate-x-1/2 rotate-6 rounded-[55%] bg-[radial-gradient(circle_at_50%_50%,rgba(60,141,13,0.24),rgba(60,141,13,0))] blur-3xl opacity-60 dark:opacity-60" aria-hidden></div>
+      <svg
+        className="absolute inset-x-0 top-20 -z-10 h-32 text-indigoBrand/12 dark:text-indigoBrand/25"
+        viewBox="0 0 1440 240"
+        preserveAspectRatio="none"
+        aria-hidden
+      >
+        <path d="M0 160c120-40 240-120 360-120s240 80 360 80 240-80 360-80 240 80 360 120v80H0z" fill="currentColor" />
+      </svg>
+    </div>
+  );
+};

--- a/apps/ui/src/components/Card.tsx
+++ b/apps/ui/src/components/Card.tsx
@@ -1,0 +1,37 @@
+import { clsx } from 'clsx';
+import { PropsWithChildren } from 'react';
+
+type CardProps = PropsWithChildren<{
+  title?: string;
+  eyebrow?: string;
+  actions?: React.ReactNode;
+  className?: string;
+}>;
+
+export const Card = ({ title, eyebrow, actions, children, className }: CardProps) => {
+  return (
+    <section
+      className={clsx(
+        'group relative overflow-hidden rounded-3xl border border-slate-200/70 bg-white/75 px-6 pb-6 pt-7 text-sm shadow-card backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/60',
+        "before:pointer-events-none before:absolute before:-right-16 before:-top-24 before:h-48 before:w-48 before:rounded-full before:bg-[radial-gradient(circle_at_50%_50%,rgba(63,81,181,0.32),rgba(63,81,181,0))] before:opacity-0 before:transition before:duration-500 before:content-[''] before:blur-3xl group-hover:before:opacity-60",
+        "after:pointer-events-none after:absolute after:bottom-0 after:left-0 after:h-1 after:w-full after:bg-[linear-gradient(90deg,rgba(0,43,127,0.65),rgba(63,81,181,0.45),rgba(244,167,29,0.45),rgba(206,17,38,0.65))] after:content-['']",
+        className
+      )}
+    >
+      {(eyebrow || title || actions) && (
+        <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            {eyebrow && (
+              <p className="text-[11px] font-semibold uppercase tracking-[0.4em] text-indigoBrand">
+                {eyebrow}
+              </p>
+            )}
+            {title && <h2 className="mt-1 text-base font-semibold text-slate-800 dark:text-slate-100">{title}</h2>}
+          </div>
+          {actions}
+        </header>
+      )}
+      <div className="relative z-10 text-sm text-slate-600 dark:text-slate-300">{children}</div>
+    </section>
+  );
+};

--- a/apps/ui/src/components/Sidebar.tsx
+++ b/apps/ui/src/components/Sidebar.tsx
@@ -1,0 +1,138 @@
+import { AppSectionKey } from '../App';
+import { ThemeMode, useTheme } from '../hooks/useTheme';
+import { ThemeToggle } from './ThemeToggle';
+
+const navIcons: Record<AppSectionKey, JSX.Element> = {
+  dashboard: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path
+        d="M4 13h7V4H4v9zm0 7h7v-5H4v5zm9 0h7V11h-7v9zm0-16v5h7V4h-7z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+  invoices: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path
+        d="M7 4h10a2 2 0 0 1 2 2v13.5l-4-2-3 2-3-2-4 2V6a2 2 0 0 1 2-2zm2 4v2h6V8H9zm0 4v2h6v-2H9z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+  vendors: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path
+        d="M12 12a4 4 0 1 0-4-4 4 4 0 0 0 4 4zm0 2c-3.31 0-9 1.66-9 5v1h18v-1c0-3.34-5.69-5-9-5z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+  reports: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path
+        d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zm3 6v10h2V9H8zm4 4v6h2v-6h-2zm4-3v9h2V10h-2z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+  approvals: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path
+        d="M9 16.17 5.83 13l-1.42 1.41L9 19l12-12-1.41-1.41L9 16.17z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+  settings: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+      <path
+        d="M19.14 12.94a7.14 7.14 0 0 0 0-1.88l2.03-1.58-1.92-3.32-2.39.95a7.15 7.15 0 0 0-1.62-.94l-.36-2.54h-3.84l-.36 2.54a7.15 7.15 0 0 0-1.62.94l-2.39-.95-1.92 3.32 2.03 1.58a7.14 7.14 0 0 0 0 1.88L3.53 14.5l1.92 3.32 2.39-.95c.5.38 1.05.69 1.62.94l.36 2.54h3.84l.36-2.54c.57-.25 1.12-.56 1.62-.94l2.39.95 1.92-3.32-2.03-1.56zM12 14.5a2.5 2.5 0 1 1 2.5-2.5A2.5 2.5 0 0 1 12 14.5z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+};
+
+type SidebarProps = {
+  sections: Array<{ id: AppSectionKey; label: string }>;
+  active: AppSectionKey;
+  onSelect: (id: AppSectionKey) => void;
+};
+
+export const Sidebar = ({ sections, active, onSelect }: SidebarProps) => {
+  const { mode, setMode } = useTheme();
+  const handleModeChange = (value: ThemeMode) => () => setMode(value);
+
+  return (
+    <aside className="relative hidden w-72 flex-col overflow-hidden border-r border-slate-200/60 bg-white/70 px-5 pb-10 pt-6 backdrop-blur-xl dark:border-slate-800/60 dark:bg-slate-950/40 lg:flex">
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(63,81,181,0.16),transparent_70%)] dark:bg-[radial-gradient(circle_at_top,rgba(0,43,127,0.28),transparent_75%)]" aria-hidden></div>
+      <div className="pointer-events-none absolute inset-y-6 right-2 w-px rounded-full bg-gradient-to-b from-transparent via-white/50 to-transparent dark:via-slate-700/60" aria-hidden></div>
+      <div className="rounded-2xl border border-white/60 bg-white/80 p-4 shadow-sm shadow-indigoBrand/10 dark:border-slate-700/60 dark:bg-slate-900/70">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.55em] text-crSun/80">Pura Vida</p>
+        <p className="mt-2 text-lg font-semibold text-slate-800 dark:text-white">Aurora Invoices</p>
+        <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">Costa Rica–crafted finance intelligence.</p>
+      </div>
+      <nav className="mt-8 flex-1 space-y-1.5 text-sm">
+        {sections.map((section) => {
+          const isActive = section.id === active;
+          return (
+            <button
+              key={section.id}
+              onClick={() => onSelect(section.id)}
+              className={`group relative flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigoBrand/70 ${
+                isActive
+                  ? 'bg-white/90 font-semibold text-indigoBrand shadow-lg shadow-indigoBrand/10 dark:bg-slate-900/70 dark:text-white'
+                  : 'text-slate-600 hover:bg-white/70 dark:text-slate-300 dark:hover:bg-slate-900/50'
+              }`}
+            >
+              <span
+                className={`flex h-9 w-9 items-center justify-center rounded-xl border border-transparent bg-white/70 text-slate-500 transition-colors dark:bg-slate-900/60 ${
+                  isActive
+                    ? 'border-indigoBrand/40 text-indigoBrand dark:border-indigoBrand/50'
+                    : 'group-hover:text-indigoBrand'
+                }`}
+              >
+                {navIcons[section.id]}
+              </span>
+              <span className="flex flex-1 items-center justify-between">
+                <span>{section.label}</span>
+                <span className="ml-3 h-1 w-6 rounded-full bg-gradient-to-r from-crBlue via-crSun to-crRed opacity-0 transition-opacity duration-300 group-hover:opacity-60" aria-hidden></span>
+              </span>
+            </button>
+          );
+        })}
+      </nav>
+      <div className="mt-10 space-y-3 rounded-2xl border border-slate-200/70 bg-white/70 p-4 text-xs shadow-sm dark:border-slate-800/70 dark:bg-slate-900/60">
+        <div className="flex items-center justify-between">
+          <p className="font-semibold uppercase tracking-[0.45em] text-slate-500 dark:text-slate-400">Theme</p>
+          <span className="h-1 w-12 rounded-full bg-gradient-to-r from-crBlue via-white to-crRed" aria-hidden></span>
+        </div>
+        <p className="text-[11px] text-slate-500 dark:text-slate-400">
+          Tune the console aura to match your workspace vibe.
+        </p>
+        <div className="grid grid-cols-3 gap-2 text-[11px] uppercase tracking-wide">
+          {(
+            [
+              { id: 'light', label: 'Light' },
+              { id: 'system', label: 'Auto' },
+              { id: 'dark', label: 'Dark' }
+            ] as Array<{ id: ThemeMode; label: string }>
+          ).map((option) => (
+            <button
+              key={option.id}
+              onClick={handleModeChange(option.id)}
+              className={`rounded-lg border px-2 py-1.5 font-medium transition ${
+                mode === option.id
+                  ? 'border-indigoBrand/40 bg-indigoBrand/10 text-indigoBrand shadow-sm shadow-indigoBrand/10'
+                  : 'border-slate-200 text-slate-500 hover:border-indigoBrand/30 dark:border-slate-700 dark:text-slate-300'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+        <ThemeToggle className="w-full justify-between" />
+      </div>
+    </aside>
+  );
+};

--- a/apps/ui/src/components/ThemeToggle.tsx
+++ b/apps/ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,36 @@
+import { clsx } from 'clsx';
+import { useTheme } from '../hooks/useTheme';
+
+type ThemeToggleProps = {
+  className?: string;
+};
+
+export const ThemeToggle = ({ className }: ThemeToggleProps) => {
+  const { mode, setMode } = useTheme();
+  const order: Array<'light' | 'dark' | 'system'> = ['light', 'dark', 'system'];
+  const nextMode = order[(order.indexOf(mode) + 1) % order.length];
+  const labelMap: Record<typeof order[number], string> = {
+    light: 'LIGHT',
+    dark: 'DARK',
+    system: 'AUTO'
+  };
+  const icon = mode === 'dark' ? '🌙' : mode === 'light' ? '☀️' : '🌤️';
+
+  return (
+    <button
+      onClick={() => setMode(nextMode)}
+      className={clsx(
+        'group relative inline-flex items-center gap-3 rounded-full border border-indigoBrand/20 bg-white/75 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.38em] text-slate-600 shadow-[0_18px_45px_-35px_rgba(0,43,127,0.9)] transition duration-300 hover:border-indigoBrand/40 hover:text-indigoBrand dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:border-crSun/40 dark:hover:text-crSun',
+        className
+      )}
+    >
+      <span className="flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-indigoBrand via-crBlue to-crSun text-base text-white shadow-inner shadow-indigoBrand/30">
+        <span aria-hidden>{icon}</span>
+      </span>
+      <span className="flex items-center gap-2">
+        <span>{labelMap[mode]}</span>
+        <span className="h-1 w-8 rounded-full bg-gradient-to-r from-crBlue via-white to-crRed opacity-70 transition group-hover:opacity-100" aria-hidden></span>
+      </span>
+    </button>
+  );
+};

--- a/apps/ui/src/components/TopBar.tsx
+++ b/apps/ui/src/components/TopBar.tsx
@@ -1,0 +1,33 @@
+import { ThemeToggle } from './ThemeToggle';
+
+type TopBarProps = {
+  title: string;
+  description: string;
+};
+
+export const TopBar = ({ title, description }: TopBarProps) => {
+  return (
+    <header className="relative z-20 border-b border-transparent bg-white/75 backdrop-blur-xl shadow-[0_1px_0_rgba(15,23,42,0.08)] dark:bg-slate-950/60">
+      <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-crBlue via-crSun to-crRed opacity-70" aria-hidden></div>
+      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6 sm:flex-row sm:items-center sm:justify-between sm:px-10">
+        <div className="flex items-start gap-4">
+          <span className="relative mt-1 flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-indigoBrand via-crBlue to-crSun text-xs font-bold uppercase tracking-[0.4em] text-white shadow-lg shadow-indigoBrand/30">
+            AIK
+            <span className="absolute -bottom-1 h-1 w-12 rounded-full bg-gradient-to-r from-crBlue via-white to-crRed" aria-hidden></span>
+          </span>
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.45em] text-crSun/80">PuraFlow Insights</p>
+            <h1 className="mt-1 text-2xl font-semibold text-slate-800 dark:text-slate-50">{title}</h1>
+            <p className="mt-1 max-w-xl text-sm text-slate-500 dark:text-slate-400">{description}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="hidden text-[10px] font-semibold uppercase tracking-[0.45em] text-slate-400 dark:text-slate-500 sm:block">
+            crafted uniquely for your team
+          </span>
+          <ThemeToggle />
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/apps/ui/src/data/mockData.ts
+++ b/apps/ui/src/data/mockData.ts
@@ -1,0 +1,189 @@
+export const kpiCards = [
+  {
+    label: 'Pending Approvals',
+    value: 8,
+    delta: '+2 vs last week',
+    trend: 'up'
+  },
+  {
+    label: 'Invoices Processed',
+    value: 142,
+    delta: '+12% efficiency',
+    trend: 'up'
+  },
+  {
+    label: 'Average Cycle Time',
+    value: '2.4d',
+    delta: '-0.6d this month',
+    trend: 'down'
+  },
+  {
+    label: 'Exceptions',
+    value: 3,
+    delta: '2 high priority',
+    trend: 'neutral'
+  }
+];
+
+export const cashFlowSeries = [
+  { day: 'Mon', value: 12 },
+  { day: 'Tue', value: 18 },
+  { day: 'Wed', value: 15 },
+  { day: 'Thu', value: 22 },
+  { day: 'Fri', value: 26 },
+  { day: 'Sat', value: 21 },
+  { day: 'Sun', value: 24 }
+];
+
+export const invoiceSummary = {
+  id: 'INV-2098',
+  vendor: 'Pura Vida Supplies',
+  issuedOn: '2025-05-02',
+  dueOn: '2025-05-16',
+  amount: '$4,860.00',
+  status: 'Awaiting Approval',
+  reference: 'PO-6635',
+  notes: 'Expedited shipping requested'
+};
+
+export const invoiceLineItems = [
+  {
+    id: '1',
+    description: 'Thermal paper rolls',
+    quantity: 120,
+    unitCost: '$12.50',
+    amount: '$1,500.00'
+  },
+  {
+    id: '2',
+    description: 'Receipt printers',
+    quantity: 15,
+    unitCost: '$120.00',
+    amount: '$1,800.00'
+  },
+  {
+    id: '3',
+    description: 'POS tablets (Wi-Fi)',
+    quantity: 6,
+    unitCost: '$220.00',
+    amount: '$1,320.00'
+  },
+  {
+    id: '4',
+    description: 'Custom cabling kit',
+    quantity: 6,
+    unitCost: '$40.00',
+    amount: '$240.00'
+  }
+];
+
+export const vendors = [
+  {
+    id: 'v-01',
+    name: 'Pura Vida Supplies',
+    category: 'Hardware',
+    contact: 'andrea@puravida.cr',
+    status: 'Active'
+  },
+  {
+    id: 'v-02',
+    name: 'San José Stationers',
+    category: 'Office Supplies',
+    contact: 'ventas@sanjose.co.cr',
+    status: 'Active'
+  },
+  {
+    id: 'v-03',
+    name: 'CloudCafe Roasters',
+    category: 'Hospitality',
+    contact: 'orders@cloudcafe.cr',
+    status: 'On Hold'
+  },
+  {
+    id: 'v-04',
+    name: 'Montezuma Analytics',
+    category: 'Consulting',
+    contact: 'sofia@montezuma.io',
+    status: 'Active'
+  },
+  {
+    id: 'v-05',
+    name: 'Tamarindo Creative',
+    category: 'Design',
+    contact: 'hola@tamarindocreative.cr',
+    status: 'Prospect'
+  }
+];
+
+export const reports = [
+  {
+    id: 'r-01',
+    title: 'Monthly Spend Overview',
+    description: 'Summary of paid vs outstanding invoices by department.',
+    updated: 'Updated 2 days ago'
+  },
+  {
+    id: 'r-02',
+    title: 'Aging Report',
+    description: 'Breakdown of invoices by 0-30, 31-60, 61-90, and 90+ days.',
+    updated: 'Updated yesterday'
+  },
+  {
+    id: 'r-03',
+    title: 'Vendor Performance',
+    description: 'Delivery, accuracy, and SLA insights by supplier.',
+    updated: 'Updated 4 days ago'
+  }
+];
+
+export const approvals = [
+  {
+    id: 'a-01',
+    title: 'Invoice INV-2098',
+    vendor: 'Pura Vida Supplies',
+    amount: '$4,860.00',
+    submitted: '2h ago',
+    status: 'Pending'
+  },
+  {
+    id: 'a-02',
+    title: 'Purchase Request PR-447',
+    vendor: 'CloudCafe Roasters',
+    amount: '$980.00',
+    submitted: '5h ago',
+    status: 'Pending'
+  },
+  {
+    id: 'a-03',
+    title: 'Contract Renewal CT-032',
+    vendor: 'Montezuma Analytics',
+    amount: '$12,400.00',
+    submitted: 'Yesterday',
+    status: 'Pending'
+  }
+];
+
+export const settingToggles = [
+  {
+    id: 'notifications',
+    label: 'Email me daily approval summaries',
+    description: 'Receive a short digest every morning at 8:00 am.'
+  },
+  {
+    id: 'autoAssign',
+    label: 'Auto-assign invoices under $1,000',
+    description: 'Automatically route small invoices to fast-track queue.'
+  },
+  {
+    id: 'reminders',
+    label: 'Enable due date reminders',
+    description: 'Send heads-up notifications 3 days before an invoice is due.'
+  }
+];
+
+export const accentSwatches = [
+  { id: 'indigo', label: 'Indigo Core', value: '#3F51B5' },
+  { id: 'flagBlue', label: 'Catalina Blue', value: '#002B7F' },
+  { id: 'flagRed', label: 'Philippine Red', value: '#CE1126' },
+  { id: 'rainforest', label: 'Rainforest Green', value: '#3C8D0D' }
+];

--- a/apps/ui/src/hooks/useTheme.tsx
+++ b/apps/ui/src/hooks/useTheme.tsx
@@ -1,0 +1,92 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+type ThemeMode = 'light' | 'dark' | 'system';
+
+type ThemeContextValue = {
+  mode: ThemeMode;
+  effectiveTheme: 'light' | 'dark';
+  setMode: (mode: ThemeMode) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'ai-invoice-theme';
+
+const getPreferredColorScheme = () => {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return 'light';
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+const applyTheme = (mode: ThemeMode) => {
+  const resolved = mode === 'system' ? getPreferredColorScheme() : mode;
+  const root = window.document.documentElement;
+  root.dataset.theme = resolved;
+  if (resolved === 'dark') {
+    root.classList.add('dark');
+  } else {
+    root.classList.remove('dark');
+  }
+  return resolved;
+};
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [mode, setMode] = useState<ThemeMode>(() => {
+    if (typeof window === 'undefined') {
+      return 'light';
+    }
+    return (window.localStorage.getItem(STORAGE_KEY) as ThemeMode) || 'system';
+  });
+  const [effectiveTheme, setEffectiveTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window === 'undefined') {
+      return 'light';
+    }
+    const stored = (window.localStorage.getItem(STORAGE_KEY) as ThemeMode) || 'system';
+    return stored === 'system' ? getPreferredColorScheme() : stored;
+  });
+
+  useEffect(() => {
+    const resolved = applyTheme(mode);
+    setEffectiveTheme(resolved);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, mode);
+    }
+  }, [mode]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => {
+      if (mode === 'system') {
+        const resolved = applyTheme('system');
+        setEffectiveTheme(resolved);
+      }
+    };
+    media.addEventListener('change', handler);
+    return () => media.removeEventListener('change', handler);
+  }, [mode]);
+
+  const value = useMemo(
+    () => ({
+      mode,
+      setMode,
+      effectiveTheme
+    }),
+    [mode, effectiveTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return ctx;
+};
+
+export type { ThemeMode };

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -1,0 +1,42 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  @apply relative min-h-screen overflow-x-hidden text-slate-900 antialiased;
+  background-color: #f4f6fb;
+  background-image: linear-gradient(135deg, rgba(238, 242, 255, 0.85), rgba(229, 245, 255, 0.6));
+}
+
+.dark body {
+  @apply text-slate-100;
+  background-color: #060b16;
+  background-image: radial-gradient(circle at 20% 20%, rgba(63, 81, 181, 0.18), transparent 60%),
+    radial-gradient(circle at 80% 12%, rgba(0, 43, 127, 0.22), transparent 62%),
+    radial-gradient(circle at 50% 85%, rgba(60, 141, 13, 0.2), transparent 70%);
+}
+
+::-webkit-scrollbar {
+  width: 0.6rem;
+}
+
+::-webkit-scrollbar-thumb {
+  @apply bg-slate-400/60 rounded-full;
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  @apply bg-slate-700 rounded-full;
+}

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/ui/src/sections/ApprovalsSection.tsx
+++ b/apps/ui/src/sections/ApprovalsSection.tsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from 'react';
+import { Card } from '../components/Card';
+import { approvals as approvalQueue } from '../data/mockData';
+
+type ApprovalState = 'Pending' | 'Approved' | 'Rejected';
+
+type ApprovalItem = {
+  id: string;
+  title: string;
+  vendor: string;
+  amount: string;
+  submitted: string;
+  status: ApprovalState;
+};
+
+export const ApprovalsSection = () => {
+  const initial = useMemo<ApprovalItem[]>(
+    () => approvalQueue.map((item) => ({ ...item })),
+    []
+  );
+  const [items, setItems] = useState(initial);
+  const [feedback, setFeedback] = useState<{ message: string; tone: 'approve' | 'reject' } | null>(null);
+
+  const handleAction = (id: string, status: ApprovalState) => {
+    setItems((prev) => prev.map((item) => (item.id === id ? { ...item, status } : item)));
+    setFeedback({
+      message: status === 'Approved' ? 'Invoice approved and routed to ERP ✅' : 'Invoice rejected with feedback 📨',
+      tone: status === 'Approved' ? 'approve' : 'reject'
+    });
+    setTimeout(() => setFeedback(null), 2600);
+  };
+
+  const pending = items.filter((item) => item.status === 'Pending');
+  const completed = items.filter((item) => item.status !== 'Pending');
+
+  return (
+    <div className="space-y-6">
+      {feedback && (
+        <div
+          className={`rounded-xl border px-4 py-3 text-sm shadow-card transition ${
+            feedback.tone === 'approve'
+              ? 'border-crGreen/40 bg-crGreen/10 text-crGreen animate-approve'
+              : 'border-crRed/40 bg-crRed/10 text-crRed animate-reject'
+          }`}
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      <Card title="Pending approvals" eyebrow="Action needed">
+        <div className="space-y-3">
+          {pending.map((item) => (
+            <div
+              key={item.id}
+              className="flex flex-col gap-3 rounded-2xl border border-slate-200/80 bg-white/70 p-4 transition hover:border-indigoBrand/60 dark:border-slate-800/80 dark:bg-slate-900/40 md:flex-row md:items-center md:justify-between"
+            >
+              <div>
+                <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">{item.title}</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  {item.vendor} • {item.amount} • {item.submitted}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => handleAction(item.id, 'Approved')}
+                  className="inline-flex items-center gap-2 rounded-full bg-indigoBrand px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:shadow"
+                >
+                  <span aria-hidden>✓</span> Approve
+                </button>
+                <button
+                  onClick={() => handleAction(item.id, 'Rejected')}
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold text-slate-500 transition hover:border-crRed hover:text-crRed"
+                >
+                  <span aria-hidden>✕</span> Reject
+                </button>
+              </div>
+            </div>
+          ))}
+          {pending.length === 0 && (
+            <div className="rounded-xl border border-slate-200/70 bg-white/40 p-6 text-sm text-slate-500 dark:border-slate-800/60 dark:bg-slate-900/30">
+              Nothing left to review — enjoy your cafecito ☕️
+            </div>
+          )}
+        </div>
+      </Card>
+
+      <Card title="History" eyebrow="Recent decisions">
+        <div className="space-y-3 text-sm">
+          {completed.map((item) => (
+            <div
+              key={item.id}
+              className={`flex items-center justify-between rounded-xl border px-4 py-3 ${
+                item.status === 'Approved'
+                  ? 'border-crGreen/40 bg-crGreen/5 text-crGreen'
+                  : 'border-crRed/40 bg-crRed/5 text-crRed'
+              }`}
+            >
+              <div>
+                <p className="font-semibold">{item.title}</p>
+                <p className="text-xs opacity-80">
+                  {item.vendor} • {item.amount}
+                </p>
+              </div>
+              <span className="text-xs font-bold uppercase tracking-wide">{item.status}</span>
+            </div>
+          ))}
+          {completed.length === 0 && (
+            <p className="text-xs text-slate-400">No decisions yet.</p>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+};

--- a/apps/ui/src/sections/DashboardSection.tsx
+++ b/apps/ui/src/sections/DashboardSection.tsx
@@ -1,0 +1,96 @@
+import { kpiCards, cashFlowSeries } from '../data/mockData';
+import { Card } from '../components/Card';
+
+const buildSparkPath = (values: number[], width: number, height: number) => {
+  if (values.length === 0) {
+    return '';
+  }
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const stepX = width / (values.length - 1 || 1);
+  return values
+    .map((value, index) => {
+      const normalized = max === min ? 0.5 : (value - min) / (max - min);
+      const x = index * stepX;
+      const y = height - normalized * height;
+      return `${index === 0 ? 'M' : 'L'}${x},${y}`;
+    })
+    .join(' ');
+};
+
+export const DashboardSection = () => {
+  const values = cashFlowSeries.map((point) => point.value);
+  const path = buildSparkPath(values, 220, 80);
+
+  return (
+    <div className="space-y-8">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {kpiCards.map((card) => (
+          <Card key={card.label} className="relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-br from-indigoBrand/5 via-transparent to-crBlue/5" aria-hidden></div>
+            <div className="relative flex flex-col gap-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                {card.label}
+              </p>
+              <span className="text-2xl font-semibold text-slate-900 dark:text-white">{card.value}</span>
+              <span
+                className={`text-xs font-medium ${
+                  card.trend === 'up'
+                    ? 'text-crGreen'
+                    : card.trend === 'down'
+                    ? 'text-crRed'
+                    : 'text-slate-500'
+                }`}
+              >
+                {card.delta}
+              </span>
+            </div>
+          </Card>
+        ))}
+      </div>
+
+      <Card title="Cash Flow Trend" eyebrow="This week" className="overflow-hidden">
+        <div className="grid gap-6 lg:grid-cols-[220px,1fr]">
+          <div>
+            <svg viewBox="0 0 220 80" className="h-24 w-full text-indigoBrand" aria-hidden>
+              <path d={path} fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+              {cashFlowSeries.map((point, index) => {
+                const max = Math.max(...values);
+                const min = Math.min(...values);
+                const stepX = 220 / (values.length - 1 || 1);
+                const normalized = max === min ? 0.5 : (point.value - min) / (max - min);
+                const x = index * stepX;
+                const y = 80 - normalized * 80;
+                return <circle key={point.day} cx={x} cy={y} r={3} className="fill-indigoBrand" />;
+              })}
+            </svg>
+            <div className="flex justify-between text-xs text-slate-500 dark:text-slate-400">
+              {cashFlowSeries.map((point) => (
+                <span key={point.day}>{point.day}</span>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-4">
+            <div className="rounded-xl border border-slate-200/70 bg-white/40 p-4 text-sm dark:border-slate-800/70 dark:bg-slate-900/40">
+              <p className="font-semibold text-slate-700 dark:text-slate-200">Today</p>
+              <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">₡13.6M collected</p>
+              <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                Collections are trending 8% above average with fewer late payments from strategic vendors.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="rounded-xl border border-slate-200/70 p-4 dark:border-slate-800/70">
+                <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Fast track queue</p>
+                <p className="mt-1 text-xl font-semibold text-slate-900 dark:text-white">14 invoices</p>
+              </div>
+              <div className="rounded-xl border border-slate-200/70 p-4 dark:border-slate-800/70">
+                <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Avg approval time</p>
+                <p className="mt-1 text-xl font-semibold text-slate-900 dark:text-white">5h 12m</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+};

--- a/apps/ui/src/sections/InvoiceViewerSection.tsx
+++ b/apps/ui/src/sections/InvoiceViewerSection.tsx
@@ -1,0 +1,81 @@
+import { Card } from '../components/Card';
+import { invoiceLineItems, invoiceSummary } from '../data/mockData';
+
+export const InvoiceViewerSection = () => {
+  return (
+    <div className="space-y-6">
+      <Card title="Invoice Summary" eyebrow="INV-2098" actions={<InvoiceActions />}>
+        <dl className="grid gap-4 sm:grid-cols-2">
+          <Item label="Vendor" value={invoiceSummary.vendor} />
+          <Item label="Status" value={invoiceSummary.status} accent="bg-amber-100 text-amber-700" />
+          <Item label="Issued" value={invoiceSummary.issuedOn} />
+          <Item label="Due" value={invoiceSummary.dueOn} />
+          <Item label="Total" value={invoiceSummary.amount} emphasis />
+          <Item label="Reference" value={invoiceSummary.reference} />
+          <div className="sm:col-span-2">
+            <Item label="Notes" value={invoiceSummary.notes} />
+          </div>
+        </dl>
+      </Card>
+
+      <Card title="Line items" eyebrow="Breakdown">
+        <div className="overflow-hidden rounded-xl border border-slate-200/70 dark:border-slate-800/70">
+          <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+            <thead className="bg-slate-50/70 text-left text-xs uppercase tracking-wide text-slate-500 dark:bg-slate-800/40 dark:text-slate-400">
+              <tr>
+                <th className="px-4 py-3">Description</th>
+                <th className="px-4 py-3">Qty</th>
+                <th className="px-4 py-3">Unit Cost</th>
+                <th className="px-4 py-3 text-right">Amount</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 text-sm dark:divide-slate-800">
+              {invoiceLineItems.map((item, index) => (
+                <tr
+                  key={item.id}
+                  className={index % 2 === 0 ? 'bg-white/70 dark:bg-slate-900/40' : 'bg-slate-50/50 dark:bg-slate-900/20'}
+                >
+                  <td className="px-4 py-3 font-medium text-slate-700 dark:text-slate-200">{item.description}</td>
+                  <td className="px-4 py-3 text-slate-500 dark:text-slate-400">{item.quantity}</td>
+                  <td className="px-4 py-3 text-slate-500 dark:text-slate-400">{item.unitCost}</td>
+                  <td className="px-4 py-3 text-right font-semibold text-slate-700 dark:text-slate-200">{item.amount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+type ItemProps = {
+  label: string;
+  value: string;
+  emphasis?: boolean;
+  accent?: string;
+};
+
+const Item = ({ label, value, emphasis, accent }: ItemProps) => (
+  <div>
+    <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</dt>
+    <dd
+      className={`mt-1 text-base ${
+        accent ? accent : emphasis ? 'font-semibold text-slate-900 dark:text-white' : 'text-slate-700 dark:text-slate-200'
+      }`}
+    >
+      {value}
+    </dd>
+  </div>
+);
+
+const InvoiceActions = () => (
+  <div className="flex gap-2">
+    <button className="rounded-full border border-indigoBrand px-4 py-2 text-xs font-semibold text-indigoBrand transition hover:bg-indigoBrand hover:text-white">
+      Approve
+    </button>
+    <button className="rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold text-slate-500 transition hover:border-crRed hover:text-crRed">
+      Reject
+    </button>
+  </div>
+);

--- a/apps/ui/src/sections/ReportsSection.tsx
+++ b/apps/ui/src/sections/ReportsSection.tsx
@@ -1,0 +1,21 @@
+import { Card } from '../components/Card';
+import { reports } from '../data/mockData';
+
+export const ReportsSection = () => {
+  return (
+    <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+      {reports.map((report) => (
+        <Card key={report.id} title={report.title} eyebrow="Report">
+          <p>{report.description}</p>
+          <div className="mt-6 flex items-center justify-between text-xs text-slate-400 dark:text-slate-500">
+            <span>{report.updated}</span>
+            <button className="inline-flex items-center gap-2 rounded-full border border-indigoBrand px-4 py-2 font-semibold text-indigoBrand transition hover:bg-indigoBrand hover:text-white">
+              <span aria-hidden>⬇️</span>
+              Download
+            </button>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+};

--- a/apps/ui/src/sections/SettingsSection.tsx
+++ b/apps/ui/src/sections/SettingsSection.tsx
@@ -1,0 +1,73 @@
+import { Card } from '../components/Card';
+import { ThemeMode, useTheme } from '../hooks/useTheme';
+import { accentSwatches, settingToggles } from '../data/mockData';
+
+export const SettingsSection = () => {
+  const { mode, setMode, effectiveTheme } = useTheme();
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <Card title="Appearance" eyebrow="Personalize">
+        <p className="text-sm">
+          Choose between light, dark, or match the system setting. Preferences persist across sessions.
+        </p>
+        <div className="mt-4 flex gap-3">
+          {(
+            [
+              { id: 'light', label: 'Light' },
+              { id: 'system', label: 'Auto' },
+              { id: 'dark', label: 'Dark' }
+            ] as Array<{ id: ThemeMode; label: string }>
+          ).map((option) => (
+            <button
+              key={option.id}
+              onClick={() => setMode(option.id)}
+              className={`flex-1 rounded-2xl border px-4 py-3 text-sm font-semibold transition ${
+                mode === option.id
+                  ? 'border-indigoBrand bg-indigoBrand/10 text-indigoBrand'
+                  : 'border-slate-200 text-slate-500 hover:border-indigoBrand/40 dark:border-slate-700 dark:text-slate-300'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+        <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">
+          Currently displaying in <span className="font-semibold text-indigoBrand">{effectiveTheme}</span> theme.
+        </p>
+      </Card>
+
+      <Card title="Notification rules" eyebrow="Automation">
+        <div className="space-y-4">
+          {settingToggles.map((toggle) => (
+            <label
+              key={toggle.id}
+              className="flex cursor-pointer items-start gap-3 rounded-2xl border border-slate-200/80 bg-white/70 p-4 transition hover:border-indigoBrand/60 dark:border-slate-800/80 dark:bg-slate-900/40"
+            >
+              <input type="checkbox" defaultChecked className="mt-1 h-4 w-4 rounded border-slate-300 text-indigoBrand focus:ring-indigoBrand" />
+              <div>
+                <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">{toggle.label}</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">{toggle.description}</p>
+              </div>
+            </label>
+          ))}
+        </div>
+      </Card>
+
+      <Card title="Accent palette" eyebrow="Costa Rica inspired" className="lg:col-span-2">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {accentSwatches.map((swatch) => (
+            <div
+              key={swatch.id}
+              className="flex flex-col items-center gap-3 rounded-2xl border border-slate-200/80 bg-white/70 p-4 dark:border-slate-800/80 dark:bg-slate-900/40"
+            >
+              <span className="h-16 w-16 rounded-full shadow-inner" style={{ backgroundColor: swatch.value }} aria-hidden></span>
+              <div className="text-center text-sm font-semibold text-slate-700 dark:text-slate-200">{swatch.label}</div>
+              <div className="text-xs text-slate-500 dark:text-slate-400">{swatch.value}</div>
+            </div>
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+};

--- a/apps/ui/src/sections/VendorListSection.tsx
+++ b/apps/ui/src/sections/VendorListSection.tsx
@@ -1,0 +1,69 @@
+import { useMemo, useState } from 'react';
+import { Card } from '../components/Card';
+import { vendors } from '../data/mockData';
+
+export const VendorListSection = () => {
+  const [query, setQuery] = useState('');
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) {
+      return vendors;
+    }
+    return vendors.filter((vendor) =>
+      [vendor.name, vendor.category, vendor.contact, vendor.status].some((field) =>
+        field.toLowerCase().includes(normalized)
+      )
+    );
+  }, [query]);
+
+  return (
+    <Card title="Vendor directory" eyebrow="Suppliers">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="relative w-full sm:w-72">
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search vendors…"
+            className="w-full rounded-full border border-slate-300 bg-white/80 px-4 py-2 text-sm text-slate-600 placeholder:text-slate-400 shadow-sm transition focus:border-indigoBrand focus:outline-none focus:ring-2 focus:ring-indigoBrand/20 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200"
+          />
+          <span className="pointer-events-none absolute inset-y-0 right-4 flex items-center text-slate-400">⌕</span>
+        </div>
+        <p className="text-xs text-slate-400 dark:text-slate-500">
+          Showing <span className="font-semibold text-indigoBrand">{filtered.length}</span> of {vendors.length} vendors
+        </p>
+      </div>
+      <div className="overflow-hidden rounded-xl border border-slate-200/70 dark:border-slate-800/70">
+        <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+          <thead className="bg-slate-50/70 text-left text-xs uppercase tracking-wide text-slate-500 dark:bg-slate-800/40 dark:text-slate-400">
+            <tr>
+              <th className="px-4 py-3">Vendor</th>
+              <th className="px-4 py-3">Category</th>
+              <th className="px-4 py-3">Contact</th>
+              <th className="px-4 py-3">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 text-sm dark:divide-slate-800">
+            {filtered.map((vendor, index) => (
+              <tr
+                key={vendor.id}
+                className={index % 2 === 0 ? 'bg-white/70 dark:bg-slate-900/40' : 'bg-slate-50/40 dark:bg-slate-900/30'}
+              >
+                <td className="px-4 py-3 font-medium text-slate-700 dark:text-slate-200">{vendor.name}</td>
+                <td className="px-4 py-3 text-slate-500 dark:text-slate-400">{vendor.category}</td>
+                <td className="px-4 py-3 text-slate-500 dark:text-slate-400">{vendor.contact}</td>
+                <td className="px-4 py-3">
+                  <span className="inline-flex items-center rounded-full bg-indigoBrand/10 px-3 py-1 text-xs font-semibold text-indigoBrand">
+                    {vendor.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {filtered.length === 0 && (
+          <div className="p-6 text-center text-sm text-slate-500 dark:text-slate-400">No vendors match your search.</div>
+        )}
+      </div>
+    </Card>
+  );
+};

--- a/apps/ui/tailwind.config.js
+++ b/apps/ui/tailwind.config.js
@@ -1,0 +1,36 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        indigoBrand: '#3F51B5',
+        crRed: '#CE1126',
+        crBlue: '#002B7F',
+        crGreen: '#3C8D0D',
+        crSun: '#F4A71D'
+      },
+      boxShadow: {
+        card: '0 10px 25px -20px rgba(0, 0, 0, 0.45)'
+      },
+      keyframes: {
+        approve: {
+          '0%': { transform: 'scale(0.9)', opacity: '0' },
+          '60%': { transform: 'scale(1.05)', opacity: '1' },
+          '100%': { transform: 'scale(1)', opacity: '1' }
+        },
+        reject: {
+          '0%': { transform: 'translateX(0)' },
+          '50%': { transform: 'translateX(-6px)' },
+          '100%': { transform: 'translateX(0)' }
+        }
+      },
+      animation: {
+        approve: 'approve 320ms ease-out',
+        reject: 'reject 260ms ease-out'
+      }
+    }
+  },
+  plugins: []
+};

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/ui/tsconfig.node.json
+++ b/apps/ui/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node16",
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"],
+    "resolveJsonModule": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -1,0 +1,22 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const outDir = path.resolve(currentDir, '..', '..', 'src/api/static/console');
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/portal/',
+  build: {
+    outDir,
+    emptyOutDir: true,
+    sourcemap: true
+  },
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});

--- a/docs/minimalist_dual_theme_app_ui.md
+++ b/docs/minimalist_dual_theme_app_ui.md
@@ -1,0 +1,56 @@
+# Minimalist Dual-Theme App UI with Indigo & Costa Rica Accents
+
+## Introduction
+This proposal outlines a minimalist user interface for an invoice-centric management application that includes Dashboard, Invoice Viewer, Vendor List, Settings, Reports, and Approval Workflow sections. The design emphasizes simplicity, usability, and support for both Light and Dark themes while highlighting an Indigo-driven brand system accented with colors inspired by Costa Rica’s natural palette and national flag.
+
+## Core Sections & Layout
+
+### Dashboard
+- Present high-priority KPIs (pending invoices, upcoming due dates, approval counts) using modular cards aligned to a responsive grid.
+- Use concise typography and minimalist charts (bar/line) with soft grid lines; accentuate alerts with subtle flag-red highlights.
+- Enable drill-down navigation from each card to detailed views while retaining generous whitespace for clarity.
+
+### Invoice Viewer
+- Split layout into a summary panel (invoice ID, vendor, dates, totals, status) and detailed line items.
+- Employ a clean table with light dividers or alternating row shading, grouping secondary information into collapsible sections.
+- Anchor primary actions (Approve, Reject, Next/Previous) in a persistent bar that uses Indigo for the main CTA.
+
+### Vendor List
+- Provide a lightweight, searchable table of vendors (Name, Company, Contact, Status) with zebra striping or subtle dividers.
+- Surface row-level actions (edit, archive) on hover via simple line icons; highlight the active row with a muted Indigo tint.
+
+### Settings
+- Organize options into clear groupings (Profile, Preferences, Notifications, Theme) rendered as cards or segmented lists with ample padding.
+- Style toggles, checkboxes, and dropdowns with Indigo active states; expose the Light/Dark/Auto theme switch prominently.
+
+### Reports
+- Offer a list or grid of report cards summarizing title, timeframe, and available actions (view, download).
+- When displaying analytics, reuse minimalist table styling and restrained charts that emphasize hierarchy through typography and spacing.
+
+### Approval Workflow
+- Present an inbox of pending approvals via concise cards or rows showing key invoice metadata and status chips.
+- Use color coding carefully: Indigo for neutral actions, a soft green for approved states, and Costa Rica flag red for critical or rejected items.
+- Mirror the Invoice Viewer layout in the detailed approval screen with clear CTA buttons and optional comment fields.
+
+## Design Style & Principles
+- **Focus on essentials:** Only display elements that support the primary task; avoid decorative graphics that do not aid comprehension.
+- **Visual hierarchy:** Guide attention through consistent typographic scale, spacing, and grouping so users can scan effortlessly.
+- **Generous whitespace:** Maintain comfortable margins and padding to reinforce the minimalist aesthetic and touch-friendly targets.
+- **Flat aesthetics:** Favor flat components with occasional subtle shadows to establish depth without clutter.
+- **Typography & iconography:** Use a single sans-serif family with defined weights for headings/body text; pair with a cohesive set of flat line icons accompanied by labels for clarity.
+
+## Dual Light & Dark Mode Strategy
+- **Light mode:** Utilize off-white or light neutral backgrounds with dark gray text; apply Indigo to interactive elements and employ gentle shadows for elevation.
+- **Dark mode:** Adopt deep charcoal surfaces (#121212 range) with near-white text (#E0E0E0) and adjust Indigo saturation for legibility; lighten divider tones to preserve contrast.
+- **Accent handling:** Calibrate accent colors for each theme (slightly softened reds/greens in dark mode) to avoid glare while maintaining brand cues.
+- **Theme consistency:** Keep layout, iconography, and typography identical across modes; offer a toggle in Settings plus an Auto option that follows system preference.
+
+## Color Scheme & Branding
+- **Primary color:** Indigo (aligned with Costa Rica’s Catalina Blue) drives navigation highlights, primary buttons, and focus states.
+- **Neutrals:** Off-whites and soft grays (light mode) plus charcoal tones (dark mode) form ~60% of the palette to sustain minimalism.
+- **Accents:** Costa Rica flag red (#CE1126) provides ~10% accent for alerts, destructive actions, and badges; a muted tropical green supports success states and references the natural landscape.
+- **Distribution:** Follow the 60-30-10 rule—neutrals (60%), Indigo and related hues (30%), accents (10%)—to maintain visual balance.
+- **Guidelines:** Document explicit usage (e.g., Indigo = primary action, red = destructive, green = success) and ensure all color combinations meet WCAG contrast ratios.
+
+## Conclusion
+The minimalist dual-theme UI delivers a cohesive, culturally resonant experience that prioritizes clarity and efficiency. Users can swiftly interpret key metrics, inspect invoices, manage vendors, adjust settings, analyze reports, and process approvals without distraction. Consistent patterns, disciplined color usage, and synchronized Light/Dark themes ensure the interface remains intuitive while celebrating the app’s Indigo identity and Costa Rican roots.


### PR DESCRIPTION
## Summary
- replace the UI workspace's legacy eslintrc with a flat config that works with ESLint 9 while keeping the React/type-aware ruleset
- bump React/Vite/TypeScript-related dependencies to the versions expected after npm audit fixes and adjust TypeScript configs for bundler resolution
- update the Vite config to use ESM-safe path handling and emit sourcemaps for the FastAPI-hosted build output
- ignore workspace node_modules so local installs don't appear as untracked files

## Testing
- python -m compileall src/api/main.py

------
https://chatgpt.com/codex/tasks/task_e_68d6de734730832990193fdd65cfd81b