### PR TITLE
Add tooling to stage license and TLS assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ ai_invoice_api*
 *.joblib
 !models/*.joblib
 node_modules/
+# Security artifacts (only the sample public verifier is tracked)
+*.pem
+*.crt
+*.key
+!keys/license_public.pem

--- a/apps/ui/src/sections/SettingsSection.tsx
+++ b/apps/ui/src/sections/SettingsSection.tsx
@@ -196,6 +196,56 @@ export const SettingsSection = () => {
           ))}
         </div>
       </Card>
+
+      <Card title="Deployment quickstart" eyebrow="Keys & certificates" className="lg:col-span-2">
+        <p className="text-sm">
+          Stage the public license verifier with the service and hand TLS materials to your reverse proxy without hunting for
+          paths. The private Ed25519 key never leaves your secrets store.
+        </p>
+
+        <div className="mt-6 grid gap-6 lg:grid-cols-2">
+          <div className="space-y-3">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Linux hosts</h3>
+            <pre className="rounded-2xl bg-slate-900/90 p-4 text-[0.7rem] leading-relaxed text-slate-100 shadow-inner">
+{String.raw`python scripts/security_provision.py stage-assets \
+  --license-public ./keys/license_public.pem \
+  --license-destination /opt/ai-invoice/keys/license_public.pem \
+  --pin-license-path --systemd-snippet \
+  --api-key $(openssl rand -hex 32) \
+  --admin-key $(openssl rand -hex 32) \
+  --tls-certificate /secure/tls/fullchain.pem \
+  --tls-key /secure/tls/privkey.pem \
+  --tls-directory /etc/ssl/ai-invoice`}
+            </pre>
+            <ul className="space-y-2 text-xs text-slate-500 dark:text-slate-400">
+              <li>Public verifier lives at <code className="rounded bg-slate-200 px-1 py-0.5 text-[0.65rem] dark:bg-slate-800">/opt/ai-invoice/keys/license_public.pem</code>.</li>
+              <li>TLS assets remain in <code className="rounded bg-slate-200 px-1 py-0.5 text-[0.65rem] dark:bg-slate-800">/etc/ssl/ai-invoice/</code> for nginx/HAProxy.</li>
+              <li className="font-semibold text-crGreen dark:text-crGreen">Restart the proxy after copying certificates; FastAPI stays HTTP-only.</li>
+            </ul>
+          </div>
+
+          <div className="space-y-3">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Windows hosts</h3>
+            <pre className="rounded-2xl bg-slate-900/90 p-4 text-[0.7rem] leading-relaxed text-slate-100 shadow-inner">
+{String.raw`python scripts/security_provision.py stage-assets \
+  --license-public .\keys\license_public.pem \
+  --license-destination C:\ai-invoice\keys\license_public.pem \
+  --pin-license-path \
+  --api-key YOUR_API_KEY \
+  --admin-key YOUR_ADMIN_KEY \
+  --tls-certificate C:\secure\tls\cert.pem \
+  --tls-key C:\secure\tls\key.pem \
+  --tls-directory C:\ai-invoice\tls`}
+            </pre>
+            <ul className="space-y-2 text-xs text-slate-500 dark:text-slate-400">
+              <li>Keep <code className="rounded bg-slate-200 px-1 py-0.5 text-[0.65rem] dark:bg-slate-800">license_private.pem</code> in your vault or HSM—this script never copies it.</li>
+              <li>Generate secrets with <code className="rounded bg-slate-200 px-1 py-0.5 text-[0.65rem] dark:bg-slate-800">python -c "import secrets; print(secrets.token_hex(32))"</code> or your vault tooling.</li>
+              <li>TLS keys can be imported into the Windows certificate store or staged in <code className="rounded bg-slate-200 px-1 py-0.5 text-[0.65rem] dark:bg-slate-800">C:\ai-invoice\tls</code> for IIS/nginx.</li>
+              <li>Update your service or scheduled task to reload environment variables after staging.</li>
+            </ul>
+          </div>
+        </div>
+      </Card>
     </div>
   );
 };

--- a/docs/license_automation.md
+++ b/docs/license_automation.md
@@ -1,0 +1,313 @@
+# License automation playbook
+
+This guide documents an internal workflow for triaging license requests, issuing
+signed tokens for approved tenants, and tracking the lifecycle of each
+subscription tier. The automation centers on the `scripts/license_workflow.py`
+helper, which orchestrates approvals and calls the existing signing pipeline.
+
+## 1. Prerequisites
+
+1. Generate the Ed25519 keypair on a secure workstation. The private key
+   (`license_private.pem`) stays in your vault; only the public verifier
+   (`license_public.pem`) is deployed with the API service.
+2. Install OpenSSL on the workstation where approvals are processed. The helper
+   invokes `openssl pkeyutl` to sign payloads with the private key.
+3. (Optional) Use `scripts/security_provision.py` to create the keypair and API
+   secrets in a repeatable way (see below).
+4. Decide where to persist the workflow ledger. By default the script stores
+   data in `data/license_requests.json`, but you can point to another location
+   with `--store` (for example, a shared network drive).
+
+## 2. Define subscription tiers
+
+The workflow ships with the following tiers out of the box:
+
+| Tier       | Duration |
+|------------|----------|
+| `monthly`  | 1 month  |
+| `quarterly`| 3 months |
+| `semester` | 6 months |
+| `annual`   | 12 months|
+| `biennial` | 24 months|
+
+For multi-year or bespoke deals, supply `--duration-months` when recording the
+request (for example, `--tier custom --duration-months 36`). The override is
+stored with the request and used during approval.
+
+## 2a. Provisioning helpers
+
+### Use the packaged `invoiceai` CLI (preferred)
+
+Installing the project in editable mode (`pip install -e .`) exposes a new
+`invoiceai` console command that wraps key lifecycle actions:
+
+```bash
+# Generate an Ed25519 license keypair (prompts before overwriting files)
+invoiceai generate license key --output-dir keys
+
+# Create matching API and admin secrets in JSON form
+invoiceai generate apikey --format json --pretty
+
+# Copy a public verifier into place and record the path in data/settings.json
+invoiceai install license ./keys/license_public.pem --destination /opt/ai-invoice/keys/license_public.pem
+
+# Persist the API key (and reuse it for the admin console) in the settings store
+invoiceai install api "$(openssl rand -hex 32)" --apply-to-admin
+
+# Verify a signed license token against the configured public key
+invoiceai validate license "$(cat /secure/tenant_license.token)" --json
+```
+
+`install` commands mutate `data/settings.json` via the internal settings store,
+so the backend sees the new secrets immediately without editing JSON by hand.
+Only public verification material is ever written; keep `license_private.pem`
+offline in your vault.
+
+### Legacy Python helper
+
+The `scripts/security_provision.py` utility bundles the same setup tasks so you
+can generate signing keys, API secrets, and environment snippets without
+copying commands by hand.
+
+### Generate a fresh Ed25519 keypair
+
+```
+python scripts/security_provision.py generate-keypair \
+  --output-dir keys \
+  --private-name license_private.pem \
+  --public-name license_public.pem
+```
+
+- Add `--password-file path/to/passphrase.txt` (or `--password secret`) to
+  encrypt the private key.
+- Use `--force` if you intentionally want to overwrite existing files.
+
+### Produce API and admin secrets
+
+```
+python scripts/security_provision.py generate-api-keys --length 64 --format env
+```
+
+This prints both `AI_API_KEY` and `ADMIN_API_KEY`. Provide `--output .env` to
+persist them, or `--format json` for machine-readable tooling.
+
+### Render deployment snippets
+
+Create environment exports for shells or CI pipelines:
+
+```
+python scripts/security_provision.py render-env \
+  --api-key <AI_API_KEY> \
+  --admin-key <ADMIN_API_KEY> \
+  --public-key-path /opt/ai-invoice/keys/license_public.pem \
+  --format bash
+```
+
+For systemd drop-ins:
+
+```
+python scripts/security_provision.py systemd-override \
+  --api-key <AI_API_KEY> \
+  --admin-key <ADMIN_API_KEY> \
+  --public-key-path /opt/ai-invoice/keys/license_public.pem \
+  --service ai-invoice.service \
+  --output /tmp/override.conf
+```
+
+If you maintain the public key inline instead of on disk, replace
+`--public-key-path` with `--public-key-inline /path/to/license_public.pem` or
+paste the PEM directly after the flag.
+
+### Stage verification and TLS assets together
+
+Use the `stage-assets` subcommand to copy an existing public verifier into its
+runtime location and, optionally, stage HTTPS materials for the proxy layer.
+This command never touches the private signing key—it remains your vault’s
+responsibility.
+
+```
+python scripts/security_provision.py stage-assets \
+  --license-public ./keys/license_public.pem \
+  --license-destination /opt/ai-invoice/keys/license_public.pem \
+  --pin-license-path --systemd-snippet \
+  --api-key "$(openssl rand -hex 32)" \
+  --admin-key "$(openssl rand -hex 32)" \
+  --tls-certificate /secure/tls/fullchain.pem \
+  --tls-key /secure/tls/privkey.pem \
+  --tls-directory /etc/ssl/ai-invoice
+```
+
+The script will:
+
+1. Copy `license_public.pem` into the destination directory (creating it if
+   needed) with restrictive permissions.
+2. Leave the private Ed25519 key untouched so it can stay in your secrets
+   infrastructure.
+3. When TLS paths are provided, copy the certificate and private key into the
+   supplied directory so your reverse proxy (NGINX, IIS, etc.) can reference
+   them.
+4. Print optional environment exports and a systemd drop-in snippet that pin
+   the new `LICENSE_PUBLIC_KEY_PATH`.
+
+> **Reminder:** The FastAPI service remains HTTP-only. Point your TLS terminator
+> at the copied certificate/key pair and forward plain HTTP traffic to the API
+> container or service once termination is complete.
+
+### Recommended locations
+
+- **Linux API hosts**
+  - License verifier: `/opt/ai-invoice/keys/license_public.pem`
+  - TLS assets (for NGINX/HAProxy): `/etc/ssl/ai-invoice/`
+
+- **Windows API hosts**
+  - License verifier: `C:\\ai-invoice\\keys\\license_public.pem`
+  - TLS assets: Windows certificate store or `C:\\ai-invoice\\tls\\` for
+    reverse proxies such as IIS or nginx-windows.
+
+Keep `license_private.pem` in your vault/HSM. If you export a TLS private key to
+disk for automation, secure the directory (`icacls`/`chmod 600`) and remove it
+after importing the key into your platform tooling.
+
+### Stage the public verifier on application hosts
+
+The running service only needs the public verifier. After generating the
+keypair, copy `license_public.pem` onto each API node while keeping the private
+key in your secrets vault.
+
+**Windows (PowerShell)**
+
+```
+New-Item -ItemType Directory -Path 'C:\ai-invoice\keys' -Force
+Copy-Item 'C:\path\to\AI-Invoice-Knowledge\keys\license_public.pem' `
+          'C:\ai-invoice\keys\license_public.pem' -Force
+
+[Environment]::SetEnvironmentVariable('LICENSE_PUBLIC_KEY_PATH', 'C:\ai-invoice\keys\license_public.pem', 'Machine')
+```
+
+**Linux (systemd)**
+
+```
+sudo install -d -m 0750 /opt/ai-invoice/keys
+sudo install -m 0640 /secure-transfer/license_public.pem /opt/ai-invoice/keys/license_public.pem
+
+sudo mkdir -p /etc/systemd/system/ai-invoice.service.d
+sudo tee /etc/systemd/system/ai-invoice.service.d/override.conf >/dev/null <<'EOF'
+[Service]
+Environment=LICENSE_PUBLIC_KEY_PATH=/opt/ai-invoice/keys/license_public.pem
+Environment=AI_API_KEY=<AI_API_KEY>
+Environment=ADMIN_API_KEY=<ADMIN_API_KEY>
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl restart ai-invoice.service
+```
+
+Replace `<AI_API_KEY>` and `<ADMIN_API_KEY>` with the generated secrets (if you
+reuse the API key for admin access, omit `ADMIN_API_KEY`). When running in
+containers or ephemeral environments, set `LICENSE_PUBLIC_KEY` to the PEM
+string instead of managing a file on disk.
+
+### TLS reminder
+
+HTTPS termination remains the responsibility of your reverse proxy, load
+balancer, or platform layer (NGINX, IIS, service mesh, etc.). The application
+exposes configuration only for API secrets and the public license verifier; it
+does not accept private keys or TLS certificates through the settings surface.
+
+## 3. Capture incoming requests
+
+Record each prospect with the `request` subcommand. You can associate metadata,
+feature flags, and free-form notes to inform the review process.
+
+```bash
+./scripts/license_workflow.py request \
+  --tenant-id acme-co \
+  --tenant-name "Acme Co" \
+  --certificate-name "Acme Co FY25" \
+  --tier quarterly \
+  --feature advanced_reports \
+  --meta plan=premium \
+  --notes "Bundle with onboarding credit"
+```
+
+`--certificate-name` lets you stamp a human-readable label onto the signed
+artifact (for example the business' legal name, billing cycle, or contract
+identifier) so downstream tooling can trace the license without relying solely
+on the tenant ID.
+
+For longer contracts:
+
+```bash
+./scripts/license_workflow.py request \
+  --tenant-id contoso-enterprise \
+  --tenant-name "Contoso Enterprise" \
+  --certificate-name "Contoso 3-Year" \
+  --tier custom \
+  --duration-months 36 \
+  --meta segment=enterprise \
+  --notes "Three-year pilot with option to extend"
+```
+
+Each request is assigned a UUID and stored with status `pending` until a
+decision is recorded.
+
+## 4. Review queue and drill into details
+
+List and filter the queue:
+
+```bash
+./scripts/license_workflow.py list              # show all requests
+./scripts/license_workflow.py list --status pending
+```
+
+Inspect an individual record:
+
+```bash
+./scripts/license_workflow.py show 1f5a0b72-...
+```
+
+## 5. Approve and issue licenses
+
+When a request is approved, the helper signs a payload with your private key and
+stores both the JSON artifact and the encoded token alongside the audit trail.
+
+```bash
+./scripts/license_workflow.py approve 1f5a0b72-... \
+  --private-key /secure/vault/license_private.pem \
+  --decision-by "Lejzer T." \
+  --start 2025-01-01 \
+  --issued-at 2024-12-15T12:00:00Z
+```
+
+If the private key is encrypted, also pass `--password-file /path/to/passphrase`.
+The script calculates the expiration using the tier duration (or the custom
+override), signs the payload, and stores the resulting token in the ledger. The
+console output summarizes the expiration date so you can communicate it back to
+the customer.
+
+## 6. Deny requests
+
+For prospects that do not meet approval criteria, record a denial with an audit
+note:
+
+```bash
+./scripts/license_workflow.py deny 1f5a0b72-... \
+  --reason "Insufficient verification" \
+  --decision-by "Compliance Bot"
+```
+
+Denied entries remain in the ledger for historical traceability.
+
+## 7. Exporting and rotating
+
+- The ledger is JSON; you can sync it to your CRM or BI tooling by parsing the
+  file and joining against billing records.
+- For rotation events, re-run `approve` with a new request to emit a fresh
+  license token, then add the previous token’s `token_id` to the revoke list in
+  the admin console.
+
+## 8. TLS and deployment reminders
+
+This workflow covers license issuance only. Continue to manage API keys via your
+secrets pipeline, stage the public verifier on application hosts, and terminate
+TLS at the load balancer or reverse proxy layer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,8 @@ where = ["src"]
   "templates/**/*.html",
   "static/**/*",
 ]
+
+[tool.setuptools.entry-points]
+console_scripts = [
+  "invoiceai=ai_invoice.cli:main",
+]

--- a/run_server.py
+++ b/run_server.py
@@ -1,4 +1,10 @@
+import os
+
 import uvicorn
 
+from ai_invoice.config import settings
+
 if __name__ == "__main__":
-    uvicorn.run("api.main:app", host="127.0.0.1", port=8088)
+    host = os.getenv("AI_INVOICE_HOST", "127.0.0.1")
+    port = int(os.getenv("AI_INVOICE_PORT", "8088"))
+    uvicorn.run("api.main:app", host=host, port=port)

--- a/scripts/generate_license.py
+++ b/scripts/generate_license.py
@@ -1,14 +1,10 @@
 #!/usr/bin/env python3
 """CLI tool for generating signed license artifacts."""
-
 from __future__ import annotations
 
 import argparse
-import base64
 import json
-import subprocess
 import sys
-import tempfile
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -19,11 +15,7 @@ SRC_DIR = PROJECT_ROOT / "src"
 if SRC_DIR.exists():
     sys.path.insert(0, str(SRC_DIR))
 
-from ai_invoice.license import canonicalize_payload, encode_license_token
-
-
-def _isoformat(dt: datetime) -> str:
-    return dt.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+from ai_invoice.license_generator import generate_license_artifact
 
 
 def _parse_datetime(value: str, *, field: str, end_of_day: bool = False) -> datetime:
@@ -75,6 +67,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--tenant-id", required=True, help="Unique tenant identifier embedded in the license.")
     parser.add_argument("--tenant-name", help="Human-friendly tenant label to embed in the license payload.")
     parser.add_argument(
+        "--certificate-name",
+        help="Optional friendly name recorded alongside the license for tracking.",
+    )
+    parser.add_argument(
         "--meta",
         action="append",
         default=[],
@@ -104,46 +100,6 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _sign_payload(private_key: Path, payload: bytes, password_file: Path | None) -> bytes:
-    with tempfile.NamedTemporaryFile(delete=False) as payload_file:
-        payload_file.write(payload)
-        payload_path = Path(payload_file.name)
-    signature_path = Path(tempfile.NamedTemporaryFile(delete=False).name)
-
-    cmd = [
-        "openssl",
-        "pkeyutl",
-        "-sign",
-        "-inkey",
-        str(private_key),
-        "-rawin",
-        "-in",
-        str(payload_path),
-        "-out",
-        str(signature_path),
-    ]
-    if password_file is not None:
-        cmd.extend(["-passin", f"file:{password_file}"])
-
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True)
-    except FileNotFoundError as exc:  # pragma: no cover - defensive
-        payload_path.unlink(missing_ok=True)
-        signature_path.unlink(missing_ok=True)
-        raise SystemExit("OpenSSL executable is required to sign licenses.") from exc
-
-    payload_path.unlink(missing_ok=True)
-    if result.returncode != 0:
-        signature_path.unlink(missing_ok=True)
-        detail = (result.stderr or result.stdout or "").strip()
-        message = f"License signing failed via OpenSSL ({detail})." if detail else "License signing failed via OpenSSL."
-        raise SystemExit(message)
-
-    signature = signature_path.read_bytes()
-    signature_path.unlink(missing_ok=True)
-    return signature
-
-
 def build_payload(args: argparse.Namespace, *, issued_at: datetime, expires_at: datetime) -> dict[str, Any]:
     tenant: dict[str, Any] = {"id": args.tenant_id}
     if args.tenant_name:
@@ -155,10 +111,12 @@ def build_payload(args: argparse.Namespace, *, issued_at: datetime, expires_at: 
     payload: dict[str, Any] = {
         "tenant": tenant,
         "features": _clean_features(args.feature),
-        "issued_at": _isoformat(issued_at),
-        "expires_at": _isoformat(expires_at),
+        "issued_at": issued_at,
+        "expires_at": expires_at,
         "token_id": str(uuid.uuid4()),
     }
+    if args.certificate_name:
+        payload["certificate"] = {"name": args.certificate_name.strip()}
     if args.device:
         payload["device"] = args.device.strip()
     if args.key_id:
@@ -180,16 +138,29 @@ def main() -> None:
         raise SystemExit(f"Password file not found: {args.password_file}")
 
     payload = build_payload(args, issued_at=issued_at, expires_at=expires_at)
-    payload_bytes = canonicalize_payload(payload)
-    signature = _sign_payload(args.private_key, payload_bytes, args.password_file)
-    artifact = {
-        "version": 1,
-        "algorithm": "ed25519",
-        "payload": payload,
-        "signature": base64.urlsafe_b64encode(signature).decode("utf-8"),
-    }
+    artifact, token = generate_license_artifact(
+        private_key=args.private_key,
+        password_file=args.password_file,
+        tenant=payload["tenant"],
+        features=payload.get("features", []),
+        issued_at=payload["issued_at"],
+        expires_at=payload["expires_at"],
+        device=payload.get("device"),
+        key_id=payload.get("key_id"),
+        token_id=payload["token_id"],
+        certificate=payload.get("certificate"),
+    )
 
-    token = encode_license_token(artifact)
+    # generate_license_artifact returns only the tenant payload; reapply any
+    # metadata that is not part of the canonical payload structure
+    artifact["payload"].update(
+        {
+            "features": payload.get("features", []),
+            "tenant": payload["tenant"],
+        }
+    )
+    if "certificate" in payload:
+        artifact["payload"]["certificate"] = payload["certificate"]
     output_data: Any
     if args.token_only:
         output_data = token

--- a/scripts/license_workflow.py
+++ b/scripts/license_workflow.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Workflow automation helper for managing tenant license approvals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from calendar import monthrange
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if SRC_DIR.exists():
+    sys.path.insert(0, str(SRC_DIR))
+
+from ai_invoice.license_generator import generate_license_artifact
+
+DEFAULT_STORE = PROJECT_ROOT / "data" / "license_requests.json"
+
+TIER_MONTHS = {
+    "monthly": 1,
+    "quarterly": 3,
+    "semester": 6,
+    "annual": 12,
+    "biennial": 24,
+}
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat(dt: datetime | None) -> str | None:
+    if dt is None:
+        return None
+    return dt.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def add_months(start: datetime, months: int) -> datetime:
+    year = start.year
+    month = start.month + months
+    day = start.day
+
+    while month > 12:
+        month -= 12
+        year += 1
+    while month <= 0:
+        month += 12
+        year -= 1
+
+    # Clamp day to end of target month
+    _, last_day = monthrange(year, month)
+    day = min(day, last_day)
+
+    return start.replace(year=year, month=month, day=day)
+
+
+@dataclass
+class LicenseRequest:
+    id: str
+    tenant_id: str
+    tier: str
+    status: str
+    submitted_at: str
+    metadata: dict[str, str]
+    features: list[str]
+    tenant_name: str | None = None
+    certificate_name: str | None = None
+    notes: str | None = None
+    custom_months: int | None = None
+    issued_at: str | None = None
+    expires_at: str | None = None
+    decision_at: str | None = None
+    decision_by: str | None = None
+    license_token: str | None = None
+    license_artifact: dict[str, Any] | None = None
+    denial_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def load_store(path: Path) -> list[LicenseRequest]:
+    if not path.exists():
+        return []
+    data = json.loads(path.read_text(encoding="utf-8"))
+    requests = []
+    for entry in data.get("requests", []):
+        requests.append(LicenseRequest(**entry))
+    return requests
+
+
+def save_store(path: Path, requests: list[LicenseRequest]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = {"requests": [req.to_dict() for req in requests]}
+    path.write_text(json.dumps(serialized, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_metadata(entries: list[str]) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    for entry in entries:
+        if "=" not in entry:
+            raise SystemExit("Metadata entries must be KEY=VALUE.")
+        key, value = entry.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise SystemExit("Metadata keys must be non-empty.")
+        metadata[key] = value.strip()
+    return metadata
+
+
+def clean_features(features: list[str]) -> list[str]:
+    cleaned: list[str] = []
+    for feature in features:
+        name = feature.strip()
+        if not name:
+            continue
+        if name not in cleaned:
+            cleaned.append(name)
+    return cleaned
+
+
+def find_request(requests: list[LicenseRequest], request_id: str) -> LicenseRequest:
+    for req in requests:
+        if req.id == request_id:
+            return req
+    raise SystemExit(f"Request {request_id} was not found.")
+
+
+def cmd_request(args: argparse.Namespace) -> None:
+    store = load_store(args.store)
+    if args.duration_months is not None and args.duration_months <= 0:
+        raise SystemExit("--duration-months must be a positive integer.")
+    if args.tier == "custom" and args.duration_months is None:
+        raise SystemExit("Custom tiers require --duration-months.")
+
+    request = LicenseRequest(
+        id=str(uuid.uuid4()),
+        tenant_id=args.tenant_id,
+        tier=args.tier,
+        status="pending",
+        submitted_at=isoformat(utc_now()),
+        metadata=parse_metadata(args.meta),
+        features=clean_features(args.feature),
+        tenant_name=args.tenant_name,
+        certificate_name=args.certificate_name,
+        notes=args.notes,
+        custom_months=args.duration_months,
+    )
+    store.append(request)
+    save_store(args.store, store)
+    print(f"Created request {request.id} for tenant {args.tenant_id} ({args.tier}).")
+
+
+def cmd_list(args: argparse.Namespace) -> None:
+    store = load_store(args.store)
+    for req in store:
+        if args.status and req.status != args.status:
+            continue
+        label = req.certificate_name or req.tenant_name or "-"
+        print(
+            f"{req.id} | {req.tenant_id:<20} | {label:<20} | {req.tier:<9} | {req.status:<9} |"
+            f" submitted {req.submitted_at}"
+        )
+
+
+def cmd_show(args: argparse.Namespace) -> None:
+    store = load_store(args.store)
+    req = find_request(store, args.request_id)
+    print(json.dumps(req.to_dict(), indent=2, sort_keys=True))
+
+
+def resolve_months(req: LicenseRequest) -> int:
+    if req.custom_months:
+        return req.custom_months
+    if req.tier not in TIER_MONTHS:
+        raise SystemExit(
+            f"Unknown tier '{req.tier}'. Provide --duration-months when requesting a custom tier."
+        )
+    return TIER_MONTHS[req.tier]
+
+
+def cmd_approve(args: argparse.Namespace) -> None:
+    store = load_store(args.store)
+    req = find_request(store, args.request_id)
+    if req.status != "pending":
+        raise SystemExit(f"Request {req.id} is already {req.status}.")
+
+    months = resolve_months(req)
+    issued_at = datetime.fromisoformat(args.issued_at.replace("Z", "+00:00")).astimezone(timezone.utc) if args.issued_at else utc_now()
+    start_at = (
+        datetime.fromisoformat(args.start.replace("Z", "+00:00")).astimezone(timezone.utc)
+        if args.start
+        else issued_at
+    )
+    expires_at = add_months(start_at, months)
+
+    private_key = Path(args.private_key)
+    if not private_key.exists():
+        raise SystemExit(f"Private key not found: {private_key}")
+    password_file = Path(args.password_file) if args.password_file else None
+    if password_file and not password_file.exists():
+        raise SystemExit(f"Password file not found: {password_file}")
+
+    tenant: dict[str, Any] = {"id": req.tenant_id}
+    if req.tenant_name:
+        tenant["name"] = req.tenant_name
+    if req.metadata:
+        tenant["metadata"] = req.metadata
+
+    certificate: dict[str, Any] | None = None
+    if req.certificate_name:
+        certificate = {"name": req.certificate_name}
+
+    artifact, token = generate_license_artifact(
+        private_key=private_key,
+        password_file=password_file,
+        tenant=tenant,
+        features=req.features,
+        issued_at=issued_at,
+        expires_at=expires_at,
+        token_id=str(uuid.uuid4()),
+        certificate=certificate,
+    )
+
+    req.status = "approved"
+    req.issued_at = isoformat(issued_at)
+    req.expires_at = isoformat(expires_at)
+    req.decision_at = isoformat(utc_now())
+    req.decision_by = args.decision_by
+    req.license_token = token
+    req.license_artifact = artifact
+    save_store(args.store, store)
+    print(f"Approved request {req.id}; license expires {req.expires_at}.")
+
+
+def cmd_deny(args: argparse.Namespace) -> None:
+    store = load_store(args.store)
+    req = find_request(store, args.request_id)
+    if req.status != "pending":
+        raise SystemExit(f"Request {req.id} is already {req.status}.")
+    req.status = "denied"
+    req.decision_at = isoformat(utc_now())
+    req.decision_by = args.decision_by
+    req.denial_reason = args.reason
+    save_store(args.store, store)
+    print(f"Denied request {req.id}.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage license approvals for AI-Invoice tenants.")
+    parser.add_argument(
+        "--store",
+        type=Path,
+        default=DEFAULT_STORE,
+        help=f"Path to the license request store (default: {DEFAULT_STORE}).",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    p_request = subparsers.add_parser("request", help="Submit a new license request.")
+    p_request.add_argument("--tenant-id", required=True)
+    p_request.add_argument("--tenant-name")
+    p_request.add_argument(
+        "--certificate-name",
+        help="Friendly label recorded with the license artifact (for example, the business legal name).",
+    )
+    p_request.add_argument(
+        "--tier",
+        choices=sorted(list(TIER_MONTHS.keys()) + ["custom"]),
+        required=True,
+        help="Subscription tier label.",
+    )
+    p_request.add_argument("--feature", action="append", default=[], help="Feature flag (repeatable).")
+    p_request.add_argument("--meta", action="append", default=[], metavar="KEY=VALUE")
+    p_request.add_argument("--notes")
+    p_request.add_argument(
+        "--duration-months",
+        type=int,
+        help="Override duration in months for custom tiers (e.g., multi-year contracts).",
+    )
+    p_request.set_defaults(func=cmd_request)
+
+    p_list = subparsers.add_parser("list", help="List license requests.")
+    p_list.add_argument("--status", choices=["pending", "approved", "denied"])
+    p_list.set_defaults(func=cmd_list)
+
+    p_show = subparsers.add_parser("show", help="Show a license request in detail.")
+    p_show.add_argument("request_id")
+    p_show.set_defaults(func=cmd_show)
+
+    p_approve = subparsers.add_parser("approve", help="Approve a pending request and issue a license.")
+    p_approve.add_argument("request_id")
+    p_approve.add_argument("--private-key", required=True, type=Path)
+    p_approve.add_argument("--password-file", type=Path)
+    p_approve.add_argument("--decision-by", help="Approver name or ID.")
+    p_approve.add_argument("--issued-at", help="Override issuance timestamp (ISO-8601).")
+    p_approve.add_argument("--start", help="Optional service start timestamp (ISO-8601).")
+    p_approve.set_defaults(func=cmd_approve)
+
+    p_deny = subparsers.add_parser("deny", help="Deny a pending request.")
+    p_deny.add_argument("request_id")
+    p_deny.add_argument("--reason", required=True)
+    p_deny.add_argument("--decision-by", help="Approver name or ID.")
+    p_deny.set_defaults(func=cmd_deny)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.store = args.store.resolve()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/security_provision.py
+++ b/scripts/security_provision.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Utilities for provisioning AI-Invoice security materials."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import secrets
+import stat
+import sys
+from pathlib import Path
+from typing import Iterable
+
+try:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+except ModuleNotFoundError as exc:  # pragma: no cover - dependency guard
+    raise SystemExit(
+        "The 'cryptography' package is required. Install project dependencies first (e.g. `pip install -e .`)."
+    ) from exc
+
+
+DEFAULT_PRIVATE_NAME = "license_private.pem"
+DEFAULT_PUBLIC_NAME = "license_public.pem"
+
+
+def _ensure_output_file(path: Path, *, force: bool = False) -> None:
+    if path.exists() and not force:
+        raise SystemExit(f"Refusing to overwrite existing file: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _write_private_key(private_key: ed25519.Ed25519PrivateKey, path: Path, *, password: bytes | None) -> None:
+    if password:
+        encryption = serialization.BestAvailableEncryption(password)
+    else:
+        encryption = serialization.NoEncryption()
+
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=encryption,
+    )
+    path.write_bytes(pem)
+    try:
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+
+
+def _write_public_key(private_key: ed25519.Ed25519PrivateKey, path: Path) -> None:
+    public_key = private_key.public_key()
+    pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    path.write_bytes(pem)
+    try:
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP)
+    except OSError:
+        pass
+
+
+def cmd_generate_keypair(args: argparse.Namespace) -> None:
+    output_dir: Path = args.output_dir
+    private_path = output_dir / args.private_name
+    public_path = output_dir / args.public_name
+
+    _ensure_output_file(private_path, force=args.force)
+    _ensure_output_file(public_path, force=args.force)
+
+    password: bytes | None = None
+    if args.password_file:
+        password = args.password_file.read_text(encoding="utf-8").rstrip("\n").encode("utf-8")
+    elif args.password:
+        password = args.password.encode("utf-8")
+
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    _write_private_key(private_key, private_path, password=password)
+    _write_public_key(private_key, public_path)
+
+    print(f"Generated private key: {private_path}")
+    print(f"Generated public key:  {public_path}")
+    if password:
+        print("Private key encrypted with supplied password.")
+
+
+def _token_hex(length: int) -> str:
+    if length <= 0:
+        raise SystemExit("--length must be positive.")
+    if length % 2:
+        raise SystemExit("--length must be an even value to map to full bytes.")
+    return secrets.token_hex(length // 2)
+
+
+def cmd_generate_api_keys(args: argparse.Namespace) -> None:
+    api_key = args.api_key or _token_hex(args.length)
+    admin_key = args.admin_key or (api_key if args.reuse_api_key else _token_hex(args.length))
+
+    if args.format == "json":
+        import json
+
+        payload = {
+            "AI_API_KEY": api_key,
+            "ADMIN_API_KEY": admin_key,
+        }
+        text = json.dumps(payload, indent=2 if args.pretty else None)
+    elif args.format == "env":
+        lines = [f"AI_API_KEY={api_key}", f"ADMIN_API_KEY={admin_key}"]
+        text = "\n".join(lines)
+    else:
+        text = (
+            "AI_API_KEY="
+            + api_key
+            + ("\nADMIN_API_KEY=" + admin_key if admin_key else "")
+        )
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+        print(f"Wrote secrets to {args.output}")
+    else:
+        print(text)
+
+
+def _resolve_inline_pem(value: str | None) -> str | None:
+    if value is None:
+        return None
+    candidate = Path(value)
+    if candidate.exists():
+        return candidate.read_text(encoding="utf-8")
+    return value
+
+
+def _render_env_lines(
+    *,
+    api_key: str,
+    admin_key: str,
+    license_key_path: str | None,
+    inline_pem: str | None,
+    algorithm: str,
+) -> list[str]:
+    lines = [f"AI_API_KEY={api_key}"]
+    lines.append(f"ADMIN_API_KEY={admin_key}")
+    lines.append(f"LICENSE_ALGORITHM={algorithm}")
+    if license_key_path and inline_pem:
+        raise SystemExit("Provide either --public-key-path or --public-key-inline, not both.")
+    if license_key_path:
+        lines.append(f"LICENSE_PUBLIC_KEY_PATH={license_key_path}")
+    elif inline_pem:
+        lines.append(f"LICENSE_PUBLIC_KEY={inline_pem}")
+    else:
+        raise SystemExit("One of --public-key-path or --public-key-inline is required.")
+    return lines
+
+
+def cmd_render_env(args: argparse.Namespace) -> None:
+    algorithm = (args.license_algorithm or "ed25519").strip().upper()
+    lines = _render_env_lines(
+        api_key=args.api_key,
+        admin_key=args.admin_key or args.api_key,
+        license_key_path=args.public_key_path,
+        inline_pem=_resolve_inline_pem(args.public_key_inline),
+        algorithm=algorithm,
+    )
+
+    if args.format == "bash":
+        text = "\n".join(f"export {line}" for line in lines)
+    elif args.format == "powershell":
+        text = "\n".join(f"$env:{line.replace('=', ' = ')}" for line in lines)
+    else:
+        text = "\n".join(lines)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+        print(f"Wrote environment snippet to {args.output}")
+    else:
+        print(text)
+
+
+def _render_systemd_block(lines: Iterable[str]) -> str:
+    env_lines = [f"Environment={line}" for line in lines]
+    block = "[Service]\n" + "\n".join(env_lines)
+    return block + "\n"
+
+
+def cmd_systemd_override(args: argparse.Namespace) -> None:
+    algorithm = (args.license_algorithm or "ed25519").strip().upper()
+    env_lines = _render_env_lines(
+        api_key=args.api_key,
+        admin_key=args.admin_key or args.api_key,
+        license_key_path=args.public_key_path,
+        inline_pem=_resolve_inline_pem(args.public_key_inline),
+        algorithm=algorithm,
+    )
+
+    override_text = _render_systemd_block(env_lines)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(override_text, encoding="utf-8")
+        print(f"Wrote systemd override to {args.output}")
+    else:
+        print(override_text, end="")
+
+    if args.service:
+        unit_dir = Path(f"/etc/systemd/system/{args.service}.d")
+        print(
+            "\nNext steps:\n"
+            f"  sudo mkdir -p {unit_dir}\n"
+            f"  sudo tee {unit_dir / 'override.conf'} >/dev/null <<'EOF'\n{override_text}EOF\n"
+            "  sudo systemctl daemon-reload\n"
+            f"  sudo systemctl restart {args.service}\n"
+        )
+
+
+def _copy_asset(source: Path, destination: Path, mode: int | None = None) -> Path:
+    if not source.is_file():
+        raise SystemExit(f"Source file not found: {source}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    if mode is not None:
+        try:
+            os.chmod(destination, mode)
+        except OSError:
+            pass
+    return destination
+
+
+def cmd_stage_assets(args: argparse.Namespace) -> None:
+    license_source = Path(args.license_public).expanduser().resolve()
+    license_destination = Path(args.license_destination).expanduser()
+
+    copied_license = _copy_asset(
+        license_source,
+        license_destination,
+        mode=stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP,
+    )
+
+    print(f"License public key copied to {copied_license}")
+    print("(Private license keys remain in your secure store; this command only stages the public verifier.)")
+
+    tls_cert_path = Path(args.tls_certificate).expanduser() if args.tls_certificate else None
+    tls_key_path = Path(args.tls_key).expanduser() if args.tls_key else None
+    tls_target_dir = Path(args.tls_directory).expanduser() if args.tls_directory else None
+
+    if any([tls_cert_path, tls_key_path, tls_target_dir]):
+        if not (tls_cert_path and tls_key_path and tls_target_dir):
+            raise SystemExit(
+                "TLS staging requires --tls-certificate, --tls-key, and --tls-directory to be supplied together."
+            )
+
+        cert_name = args.tls_certificate_name or tls_cert_path.name
+        key_name = args.tls_key_name or tls_key_path.name
+
+        copied_cert = _copy_asset(
+            tls_cert_path,
+            tls_target_dir / cert_name,
+            mode=stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP,
+        )
+        copied_key = _copy_asset(
+            tls_key_path,
+            tls_target_dir / key_name,
+            mode=stat.S_IRUSR | stat.S_IWUSR,
+        )
+
+        print(f"TLS certificate copied to {copied_cert}")
+        print(f"TLS private key copied to {copied_key}")
+        print(
+            "Reminder: configure your reverse proxy or load balancer to reference these TLS assets; the FastAPI service remains HTTP-only."
+        )
+
+    env_lines: list[str] = []
+    if args.pin_license_path or args.systemd_snippet:
+        api_value = args.api_key or "CHANGE_ME_API_KEY"
+        admin_value = args.admin_key or (args.api_key if args.api_key else "CHANGE_ME_ADMIN_KEY")
+        env_lines = _render_env_lines(
+            api_key=api_value,
+            admin_key=admin_value,
+            license_key_path=str(license_destination),
+            inline_pem=None,
+            algorithm=(args.license_algorithm or "ed25519").strip().upper(),
+        )
+
+    if args.pin_license_path and env_lines:
+        print("\nSuggested environment overrides:")
+        for line in env_lines:
+            print(f"  {line}")
+
+    if args.systemd_snippet and env_lines:
+        print("\nSystemd drop-in example (override.conf):\n")
+        print(_render_systemd_block(env_lines))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Provision security assets for AI-Invoice deployments.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    keypair = subparsers.add_parser("generate-keypair", help="Create an Ed25519 keypair for license signing.")
+    keypair.add_argument("--output-dir", type=Path, default=Path("keys"), help="Directory to write the keypair.")
+    keypair.add_argument("--private-name", default=DEFAULT_PRIVATE_NAME, help="Filename for the private key.")
+    keypair.add_argument("--public-name", default=DEFAULT_PUBLIC_NAME, help="Filename for the public key.")
+    keypair.add_argument("--password-file", type=Path, help="File containing password to encrypt the private key.")
+    keypair.add_argument("--password", help="Password string to encrypt the private key (use with caution).")
+    keypair.add_argument("--force", action="store_true", help="Overwrite existing files if they exist.")
+    keypair.set_defaults(func=cmd_generate_keypair)
+
+    secrets_parser = subparsers.add_parser("generate-api-keys", help="Generate API and admin keys.")
+    secrets_parser.add_argument("--length", type=int, default=64, help="Length of generated hex tokens (default: 64).")
+    secrets_parser.add_argument("--api-key", help="Provide an explicit API key instead of generating one.")
+    secrets_parser.add_argument("--admin-key", help="Provide an explicit admin key instead of generating one.")
+    secrets_parser.add_argument(
+        "--reuse-api-key",
+        action="store_true",
+        help="Use the API key for admin access when no admin key is supplied.",
+    )
+    secrets_parser.add_argument(
+        "--format",
+        choices=("env", "json", "text"),
+        default="env",
+        help="Output format (default: env).",
+    )
+    secrets_parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
+    secrets_parser.add_argument("--output", type=Path, help="Write secrets to a file instead of stdout.")
+    secrets_parser.set_defaults(func=cmd_generate_api_keys)
+
+    env_parser = subparsers.add_parser("render-env", help="Render environment exports for the service.")
+    env_parser.add_argument("--api-key", required=True, help="AI_API_KEY value.")
+    env_parser.add_argument("--admin-key", help="ADMIN_API_KEY value (defaults to API key).")
+    env_parser.add_argument("--public-key-path", help="Filesystem path to license_public.pem.")
+    env_parser.add_argument(
+        "--public-key-inline",
+        help="Path to a PEM file that should be inlined into LICENSE_PUBLIC_KEY.",
+    )
+    env_parser.add_argument(
+        "--format",
+        choices=("env", "bash", "powershell"),
+        default="env",
+        help="Output style for the exports (default: env).",
+    )
+    env_parser.add_argument("--license-algorithm", default="ed25519", help="License algorithm to advertise.")
+    env_parser.add_argument("--output", type=Path, help="Write snippet to a file.")
+    env_parser.set_defaults(func=cmd_render_env)
+
+    systemd_parser = subparsers.add_parser("systemd-override", help="Generate a systemd override snippet.")
+    systemd_parser.add_argument("--api-key", required=True, help="AI_API_KEY value.")
+    systemd_parser.add_argument("--admin-key", help="ADMIN_API_KEY value (defaults to API key).")
+    systemd_parser.add_argument("--public-key-path", help="Filesystem path to license_public.pem.")
+    systemd_parser.add_argument(
+        "--public-key-inline",
+        help="Path to a PEM file that should be inlined into LICENSE_PUBLIC_KEY.",
+    )
+    systemd_parser.add_argument("--license-algorithm", default="ed25519", help="License algorithm name.")
+    systemd_parser.add_argument("--output", type=Path, help="Write override.conf to this path.")
+    systemd_parser.add_argument(
+        "--service",
+        help="Name of the systemd service (used when printing follow-up commands).",
+    )
+    systemd_parser.set_defaults(func=cmd_systemd_override)
+
+    stage_parser = subparsers.add_parser(
+        "stage-assets",
+        help="Copy the public license key (and optional TLS materials) into deployment directories.",
+    )
+    stage_parser.add_argument(
+        "--license-public",
+        type=Path,
+        required=True,
+        help="Source path to the generated license_public.pem file.",
+    )
+    stage_parser.add_argument(
+        "--license-destination",
+        type=Path,
+        default=Path("/opt/ai-invoice/keys/license_public.pem"),
+        help="Filesystem destination for the public verifier on the API host.",
+    )
+    stage_parser.add_argument("--api-key", help="AI_API_KEY to include in optional snippets.")
+    stage_parser.add_argument(
+        "--admin-key",
+        help="ADMIN_API_KEY to include in optional snippets (defaults to API key placeholder).",
+    )
+    stage_parser.add_argument(
+        "--license-algorithm",
+        default="ed25519",
+        help="License algorithm identifier to include in optional snippets.",
+    )
+    stage_parser.add_argument(
+        "--pin-license-path",
+        action="store_true",
+        help="Print environment variable exports pointing at the destination path.",
+    )
+    stage_parser.add_argument(
+        "--systemd-snippet",
+        action="store_true",
+        help="Render a sample systemd override block with the license path pinned.",
+    )
+    stage_parser.add_argument(
+        "--tls-certificate",
+        type=Path,
+        help="Optional TLS certificate (PEM) to copy alongside the license key.",
+    )
+    stage_parser.add_argument(
+        "--tls-key",
+        type=Path,
+        help="Optional TLS private key to copy alongside the license key.",
+    )
+    stage_parser.add_argument(
+        "--tls-directory",
+        type=Path,
+        help="Destination directory for TLS assets (required when TLS files are provided).",
+    )
+    stage_parser.add_argument(
+        "--tls-certificate-name",
+        help="Filename to use when writing the TLS certificate (defaults to source name).",
+    )
+    stage_parser.add_argument(
+        "--tls-key-name",
+        help="Filename to use when writing the TLS private key (defaults to source name).",
+    )
+    stage_parser.set_defaults(func=cmd_stage_assets)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/ai_invoice/cli.py
+++ b/src/ai_invoice/cli.py
@@ -1,0 +1,381 @@
+"""Command-line interface for provisioning AI-Invoice secrets and licenses."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+except ModuleNotFoundError as exc:  # pragma: no cover - dependency guard
+    raise SystemExit(
+        "The 'cryptography' package is required. Install project dependencies first (e.g. `pip install -e .`)."
+    ) from exc
+
+from ai_invoice.license import LicenseExpiredError, LicenseVerificationError, LicenseVerifier
+from ai_invoice.settings_store import SettingsStore
+
+DEFAULT_PRIVATE_NAME = "license_private.pem"
+DEFAULT_PUBLIC_NAME = "license_public.pem"
+DEFAULT_KEYS_DIR = Path("keys")
+
+
+@dataclass(slots=True)
+class SettingsMutation:
+    """Representation of a settings update operation."""
+
+    description: str
+    data: dict[str, Any]
+
+
+def _store_path() -> SettingsStore:
+    return SettingsStore()
+
+
+def _load_settings() -> dict[str, Any]:
+    return _store_path().load()
+
+
+def _save_settings(payload: dict[str, Any]) -> None:
+    _store_path().save(payload)
+
+
+def _token_hex(length: int) -> str:
+    if length <= 0:
+        raise SystemExit("--length must be positive.")
+    if length % 2:
+        raise SystemExit("--length must be an even value to map to full bytes.")
+    return secrets.token_hex(length // 2)
+
+
+def _normalize_destination(path: str | None) -> Path:
+    if path is None or path.strip() == "":
+        return (Path.cwd() / DEFAULT_KEYS_DIR / DEFAULT_PUBLIC_NAME).resolve()
+    return Path(path).expanduser().resolve()
+
+
+def _write_private_key(private_key: ed25519.Ed25519PrivateKey, path: Path, *, password: bytes | None) -> None:
+    if password:
+        encryption = serialization.BestAvailableEncryption(password)
+    else:
+        encryption = serialization.NoEncryption()
+
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=encryption,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(pem)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def _write_public_key(private_key: ed25519.Ed25519PrivateKey, path: Path) -> None:
+    pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(pem)
+    try:
+        os.chmod(path, 0o640)
+    except OSError:
+        pass
+
+
+def cmd_generate_license_key(args: argparse.Namespace) -> None:
+    private_path = Path(args.output_dir).expanduser() / (args.private_name or DEFAULT_PRIVATE_NAME)
+    public_path = Path(args.output_dir).expanduser() / (args.public_name or DEFAULT_PUBLIC_NAME)
+
+    if not args.force:
+        for candidate in (private_path, public_path):
+            if candidate.exists():
+                raise SystemExit(f"Refusing to overwrite existing file: {candidate}")
+
+    password: bytes | None = None
+    if args.password_file:
+        password = Path(args.password_file).expanduser().read_text(encoding="utf-8").rstrip("\n").encode("utf-8")
+    elif args.password:
+        password = args.password.encode("utf-8")
+
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    _write_private_key(private_key, private_path, password=password)
+    _write_public_key(private_key, public_path)
+
+    print(f"Generated private key: {private_path}")
+    print(f"Generated public key:  {public_path}")
+    if password:
+        print("Private key encrypted with supplied password.")
+
+
+def cmd_generate_api_key(args: argparse.Namespace) -> None:
+    api_key = args.api_key or _token_hex(args.length)
+    admin_key = args.admin_key or (api_key if args.reuse_api_key else _token_hex(args.length))
+
+    if args.format == "json":
+        payload = {"AI_API_KEY": api_key, "ADMIN_API_KEY": admin_key}
+        text = json.dumps(payload, indent=2 if args.pretty else None)
+    elif args.format == "env":
+        lines = [f"AI_API_KEY={api_key}", f"ADMIN_API_KEY={admin_key}"]
+        text = "\n".join(lines)
+    else:
+        text = f"AI_API_KEY={api_key}\nADMIN_API_KEY={admin_key}".strip()
+
+    if args.output:
+        output_path = Path(args.output).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(text + "\n", encoding="utf-8")
+        print(f"Wrote secrets to {output_path}")
+    else:
+        print(text)
+
+
+def _prepare_settings_mutation(update: dict[str, Any]) -> SettingsMutation:
+    stored = _load_settings()
+    stored.update(update)
+    return SettingsMutation(description="settings", data=stored)
+
+
+def _apply_mutation(mutation: SettingsMutation) -> None:
+    _save_settings(mutation.data)
+    print(f"Updated {mutation.description} store at {_store_path().path}.")
+
+
+def cmd_install_api(args: argparse.Namespace) -> None:
+    admin_value = args.admin_key or (args.api_key if args.apply_to_admin else None)
+    update: dict[str, Any] = {"api_key": args.api_key}
+    if args.allow_anonymous is not None:
+        update["allow_anonymous"] = bool(args.allow_anonymous)
+    if admin_value:
+        update["admin_api_key"] = admin_value
+    elif args.clear_admin:
+        update["admin_api_key"] = None
+
+    mutation = _prepare_settings_mutation(update)
+    _apply_mutation(mutation)
+    print("Stored API key in settings store.")
+    if admin_value:
+        print("Stored admin API key in settings store.")
+    elif args.clear_admin:
+        print("Cleared admin API key from settings store.")
+
+
+def _coerce_inline_pem(value: str | None) -> str | None:
+    if value is None:
+        return None
+    candidate = Path(value)
+    if candidate.exists():
+        return candidate.read_text(encoding="utf-8")
+    return value
+
+
+def cmd_install_license(args: argparse.Namespace) -> None:
+    algorithm = (args.algorithm or "ed25519").strip().upper()
+    source = Path(args.license).expanduser()
+
+    if args.inline:
+        pem_data = _coerce_inline_pem(args.license)
+        if pem_data is None:
+            raise SystemExit("Inline license data is empty.")
+        update = {
+            "license_public_key": pem_data.strip(),
+            "license_public_key_path": None,
+            "license_algorithm": algorithm,
+        }
+        mutation = _prepare_settings_mutation(update)
+        _apply_mutation(mutation)
+        print("Stored inline public key in settings store.")
+        return
+
+    if source.exists():
+        destination = _normalize_destination(args.destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        update = {
+            "license_public_key_path": str(destination),
+            "license_public_key": None,
+            "license_algorithm": algorithm,
+        }
+        mutation = _prepare_settings_mutation(update)
+        _apply_mutation(mutation)
+        print(f"Copied license public key to {destination}.")
+    else:
+        pem_data = args.license.strip()
+        if not pem_data:
+            raise SystemExit("License value must be a PEM string or path to a PEM file.")
+        update = {
+            "license_public_key": pem_data,
+            "license_public_key_path": None,
+            "license_algorithm": algorithm,
+        }
+        mutation = _prepare_settings_mutation(update)
+        _apply_mutation(mutation)
+        print("Stored inline public key in settings store.")
+
+
+def _resolve_verifier(args: argparse.Namespace) -> LicenseVerifier:
+    if args.public_key:
+        pem_data = _coerce_inline_pem(args.public_key)
+        if not pem_data:
+            raise SystemExit("--public-key must point to a PEM file or contain PEM text.")
+        return LicenseVerifier.from_public_key_string(pem_data)
+
+    if args.public_key_path:
+        return LicenseVerifier.from_public_key_path(args.public_key_path)
+
+    stored = _load_settings()
+    inline = stored.get("license_public_key")
+    path = stored.get("license_public_key_path")
+    if inline:
+        return LicenseVerifier.from_public_key_string(str(inline))
+    if path:
+        return LicenseVerifier.from_public_key_path(path)
+    raise SystemExit(
+        "No license public key configured. Provide --public-key or --public-key-path, or install a key first."
+    )
+
+
+def cmd_validate_license(args: argparse.Namespace) -> None:
+    verifier = _resolve_verifier(args)
+    token = args.license.strip()
+    if not token:
+        raise SystemExit("License token must not be empty.")
+
+    try:
+        payload = verifier.verify_token(token)
+    except LicenseExpiredError as exc:
+        raise SystemExit(f"License token has expired: {exc}") from exc
+    except LicenseVerificationError as exc:
+        raise SystemExit(f"License token is invalid: {exc}") from exc
+
+    print("License token is valid.")
+    if args.json:
+        print(json.dumps(payload.model_dump(mode="json"), indent=2, sort_keys=True))
+    else:
+        print("Tenant ID:", payload.tenant.id)
+        print("Features:", ", ".join(sorted(payload.features)))
+        print("Issued at:", payload.issued_at.isoformat())
+        print("Expires at:", payload.expires_at.isoformat())
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="invoiceai", description="AI-Invoice deployment helper CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    # generate group
+    generate = subparsers.add_parser("generate", help="Generate secrets and key material")
+    gen_sub = generate.add_subparsers(dest="generate_command")
+
+    license_parser = gen_sub.add_parser("license", help="Generate an Ed25519 license keypair")
+    license_parser.set_defaults(func=cmd_generate_license_key)
+    license_parser.add_argument("--output-dir", default=str(DEFAULT_KEYS_DIR), help="Directory to place the keypair")
+    license_parser.add_argument("--private-name", help="Filename for the private key (default license_private.pem)")
+    license_parser.add_argument("--public-name", help="Filename for the public key (default license_public.pem)")
+    license_parser.add_argument("--force", action="store_true", help="Overwrite existing files")
+    license_parser.add_argument("--password", help="Encrypt the private key with this password")
+    license_parser.add_argument("--password-file", help="Read the private key password from a file")
+
+    license_key_parser = license_parser.add_subparsers(dest="license_sub")
+    license_key_alias = license_key_parser.add_parser("key", help=argparse.SUPPRESS)
+    license_key_alias.set_defaults(func=cmd_generate_license_key)
+
+    api_parser = gen_sub.add_parser("apikey", aliases=["api-key", "api"], help="Generate API credentials")
+    api_parser.set_defaults(func=cmd_generate_api_key)
+    api_parser.add_argument("--length", type=int, default=64, help="Total hex length for generated keys (default 64)")
+    api_parser.add_argument("--api-key", help="Provide an explicit API key instead of generating one")
+    api_parser.add_argument("--admin-key", help="Provide an explicit admin API key")
+    api_parser.add_argument("--reuse-api-key", action="store_true", help="Use the same value for admin as API key")
+    api_parser.add_argument("--format", choices=["plain", "json", "env"], default="plain", help="Output format")
+    api_parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
+    api_parser.add_argument("--output", help="Write results to this file instead of stdout")
+
+    # install group
+    install = subparsers.add_parser("install", help="Install secrets into the local settings store")
+    install_sub = install.add_subparsers(dest="install_command")
+
+    install_api = install_sub.add_parser("api", help="Persist API credentials to data/settings.json")
+    install_api.set_defaults(func=cmd_install_api)
+    install_api.add_argument("api_key", help="API key to store in settings")
+    install_api.add_argument("--admin-key", help="Optional admin API key to store")
+    install_api.add_argument(
+        "--apply-to-admin",
+        action="store_true",
+        help="Reuse the provided API key as the admin key when --admin-key is not supplied",
+    )
+    install_api.add_argument(
+        "--clear-admin",
+        action="store_true",
+        help="Remove any stored admin API key when --admin-key is omitted",
+    )
+    install_api.add_argument(
+        "--allow-anonymous",
+        dest="allow_anonymous",
+        action="store_true",
+        help="Set allow_anonymous=true in the settings store",
+    )
+    install_api.add_argument(
+        "--no-allow-anonymous",
+        dest="allow_anonymous",
+        action="store_false",
+        help="Set allow_anonymous=false in the settings store",
+    )
+    install_api.set_defaults(allow_anonymous=None)
+
+    install_license = install_sub.add_parser("license", help="Copy or embed the license public key")
+    install_license.set_defaults(func=cmd_install_license)
+    install_license.add_argument("license", help="Path to the public key PEM or inline PEM data")
+    install_license.add_argument(
+        "--destination",
+        help="Destination path for the public key file (default keys/license_public.pem)",
+    )
+    install_license.add_argument(
+        "--inline",
+        action="store_true",
+        help="Treat the provided value as inline PEM even if it looks like a file path",
+    )
+    install_license.add_argument(
+        "--algorithm",
+        default="ed25519",
+        help="License verification algorithm to record (default ed25519)",
+    )
+
+    # validate group
+    validate = subparsers.add_parser("validate", help="Validate artifacts against configured keys")
+    validate_sub = validate.add_subparsers(dest="validate_command")
+
+    validate_license = validate_sub.add_parser("license", help="Validate a signed license token")
+    validate_license.set_defaults(func=cmd_validate_license)
+    validate_license.add_argument("license", help="Signed license token to verify")
+    validate_license.add_argument("--json", action="store_true", help="Print the validated payload as JSON")
+    validate_license.add_argument("--public-key", help="PEM string or file containing the license public key")
+    validate_license.add_argument("--public-key-path", help="Path to the license public key")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return 0
+    try:
+        args.func(args)
+    except KeyboardInterrupt:  # pragma: no cover - user abort
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/src/ai_invoice/license_generator.py
+++ b/src/ai_invoice/license_generator.py
@@ -1,0 +1,110 @@
+"""Helpers for creating signed license artifacts."""
+
+from __future__ import annotations
+
+import base64
+import subprocess
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .license import canonicalize_payload, encode_license_token
+
+
+def isoformat_utc(dt: datetime) -> str:
+    """Return an ISO-8601 timestamp in UTC with trailing ``Z``."""
+    return dt.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def sign_payload(private_key: Path, payload: bytes, password_file: Path | None = None) -> bytes:
+    """Sign ``payload`` with the Ed25519 private key using OpenSSL."""
+    with tempfile.NamedTemporaryFile(delete=False) as payload_file:
+        payload_file.write(payload)
+        payload_path = Path(payload_file.name)
+
+    signature_path = Path(tempfile.NamedTemporaryFile(delete=False).name)
+
+    cmd = [
+        "openssl",
+        "pkeyutl",
+        "-sign",
+        "-inkey",
+        str(private_key),
+        "-rawin",
+        "-in",
+        str(payload_path),
+        "-out",
+        str(signature_path),
+    ]
+    if password_file is not None:
+        cmd.extend(["-passin", f"file:{password_file}"])
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+    except FileNotFoundError as exc:  # pragma: no cover - defensive
+        payload_path.unlink(missing_ok=True)
+        signature_path.unlink(missing_ok=True)
+        raise RuntimeError("OpenSSL executable is required to sign licenses.") from exc
+
+    payload_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        signature_path.unlink(missing_ok=True)
+        detail = (result.stderr or result.stdout or "").strip()
+        message = (
+            f"License signing failed via OpenSSL ({detail})."
+            if detail
+            else "License signing failed via OpenSSL."
+        )
+        raise RuntimeError(message)
+
+    signature = signature_path.read_bytes()
+    signature_path.unlink(missing_ok=True)
+    return signature
+
+
+def generate_license_artifact(
+    *,
+    private_key: Path,
+    password_file: Path | None,
+    tenant: dict[str, Any],
+    features: list[str] | None,
+    issued_at: datetime,
+    expires_at: datetime,
+    device: str | None = None,
+    key_id: str | None = None,
+    token_id: str | None = None,
+    certificate: dict[str, Any] | None = None,
+    algorithm: str = "ed25519",
+) -> tuple[dict[str, Any], str]:
+    """Build and sign a license artifact, returning the artifact and encoded token.
+
+    ``certificate`` can include human-readable metadata (for example, a contract
+    or business name) that is embedded alongside the canonical payload.
+    """
+    payload: dict[str, Any] = {
+        "tenant": tenant,
+        "features": features or [],
+        "issued_at": isoformat_utc(issued_at),
+        "expires_at": isoformat_utc(expires_at),
+        "token_id": token_id or str(uuid.uuid4()),
+    }
+    if device:
+        payload["device"] = device
+    if key_id:
+        payload["key_id"] = key_id
+    if certificate:
+        payload["certificate"] = certificate
+
+    payload_bytes = canonicalize_payload(payload)
+    signature = sign_payload(private_key, payload_bytes, password_file)
+
+    artifact = {
+        "version": 1,
+        "algorithm": algorithm,
+        "payload": payload,
+        "signature": base64.urlsafe_b64encode(signature).decode("utf-8"),
+    }
+    token = encode_license_token(artifact)
+    return artifact, token

--- a/tests/test_settings_admin.py
+++ b/tests/test_settings_admin.py
@@ -63,7 +63,6 @@ def test_admin_endpoints_apply_updates(tmp_path: Path, monkeypatch: pytest.Monke
     ]
     updated_model.license_algorithm = "RS512"
     updated_model.admin_api_key = "rotated-admin"
-
     result = admin.update_settings(updated_model)
     assert result.values.max_upload_bytes == 654321
     assert result.values.admin_api_key == "rotated-admin"
@@ -84,8 +83,6 @@ def test_admin_endpoints_apply_updates(tmp_path: Path, monkeypatch: pytest.Monke
     monkeypatch.delenv("AI_INVOICE_SETTINGS_PATH", raising=False)
     monkeypatch.setenv("AI_API_KEY", "pytest-default-key")
     config.reload_settings()
-
-
 def test_predictive_path_update_reflected_in_model(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- extend `scripts/security_provision.py` with a `stage-assets` subcommand that copies the public verifier, optionally stages TLS cert/key pairs, and emits environment or systemd snippets for the pinned path
- expand the license automation playbook with recommended Linux/Windows locations and reminders that TLS stays at the proxy layer
- surface deployment quickstart cards in the admin settings UI so operators can copy platform-specific commands
- update .gitignore to avoid accidentally committing secrets and TLS material

## Testing
- `python -m compileall scripts/security_provision.py`


------
https://chatgpt.com/codex/tasks/task_e_68d71e7c6e80832980da16eb5607e164